### PR TITLE
Converting from base64 byte array to xml

### DIFF
--- a/NServiceBus.Profiler.Core/MessageDecoders/XmlContentDecoder.cs
+++ b/NServiceBus.Profiler.Core/MessageDecoders/XmlContentDecoder.cs
@@ -13,7 +13,10 @@ namespace NServiceBus.Profiler.Core.MessageDecoders
             {
                 try
                 {
-                    var xml = Encoding.UTF8.GetString(content);
+                    var base64EncodedString = Encoding.UTF8.GetString(content);
+                    byte[] encodedDataAsBytes = System.Convert.FromBase64String(base64EncodedString);
+                    string xml = Encoding.UTF8.GetString(encodedDataAsBytes);
+
                     doc.LoadXml(xml);
                     return new DecoderResult<XmlDocument>(doc);
                 }


### PR DESCRIPTION
Hi @HEskandari, 

Finally figured out what the problem is with the xml not being displayed.

The problem is that we use Json.Net to convert the http REST response to json and Json.Net serializer uses base64 encoding to serialize `byte[]`, see http://james.newtonking.com/archive/2010/02/07/json-net-performance-with-binary-data.aspx

On the Profiler end, the RestSharp deserializes the response using its own JSON deserializer which does not understand how to deserialize the base64 string!, see https://github.com/restsharp/RestSharp/wiki/Deserialization

So we I had to double decode it!

IMHO, I think we should change the RestSharp JSON deserializer to use Json.Net so we avoid other possible issues in the future.

Thoughts?
