### PR TITLE
Saga View window scroll is not consistent

### DIFF
--- a/src/ServiceInsight/Saga/SagaWindowView.xaml
+++ b/src/ServiceInsight/Saga/SagaWindowView.xaml
@@ -37,9 +37,9 @@
                                                Foreground="{StaticResource SagaBlue}"
                                                Text="&#x2190; Back to Message View"
                                                cal:Message.Attach="[Event MouseLeftButtonUp]=[Action ShowFlow]" />
-                                    <Border Padding="0 5 0 5"
-                                            BorderBrush="{StaticResource SagaBlue}"
-                                            BorderThickness="0 0 0 2">
+                                    <Border BorderBrush="{StaticResource SagaBlue}"
+                                            BorderThickness="0 0 0 2"
+                                            Padding="0 5 0 5">
                                         <dxe:TextEdit EditMode="InplaceInactive"
                                                       FontSize="24"
                                                       FontWeight="Bold"
@@ -169,10 +169,10 @@
                         <StackPanel Margin="5,2,5,5"
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal">
-                            <TextBlock Padding="2"
-                                       Background="{x:Null}"
+                            <TextBlock Background="{x:Null}"
                                        FontFamily="Consolas"
                                        FontSize="16"
+                                       Padding="2"
                                        Style="{StaticResource CodeStyle}"
                                        Text="For NSB v5 endpoints, install-package ServiceControl.Plugin.Nsb5.SagaAudit" />
                             <Button Margin="5,0,0,0"
@@ -186,10 +186,10 @@
                         <StackPanel Margin="5,2,5,5"
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal">
-                            <TextBlock Padding="2"
-                                       Background="{x:Null}"
+                            <TextBlock Background="{x:Null}"
                                        FontFamily="Consolas"
                                        FontSize="16"
+                                       Padding="2"
                                        Style="{StaticResource CodeStyle}"
                                        Text="For NSB v4 endpoints, install-package ServiceControl.Plugin.Nsb4.SagaAudit" />
                             <Button Margin="5,0,0,0"
@@ -210,6 +210,13 @@
                           Style="{StaticResource ItemsControlVirtualisedStyle}"
                           Visibility="{Binding HasSaga,
                                                Converter={StaticResource BoolToVisibilityConverter}}">
+                <ItemsControl.Template>
+                    <ControlTemplate>
+                        <ScrollViewer x:Name="ScrollViewer" Padding="{TemplateBinding Padding}" CanContentScroll="False">
+                            <ItemsPresenter />
+                        </ScrollViewer>
+                    </ControlTemplate>
+                </ItemsControl.Template>
                 <ItemsControl.ItemsSource>
                     <MultiBinding Converter="{StaticResource CompositeCollectionConverter}">
                         <Binding Path="Header" />


### PR DESCRIPTION
* Scrolling up and down the Saga View with the scroll option is fine (either with the mouse or with the up/down arrows

![image](https://cloud.githubusercontent.com/assets/3889023/3535210/624c4766-07fc-11e4-8e92-26217a0ce743.png)

* However, the scroll behavior is erratic, and its size changes (see below and compare to the above)

![image](https://cloud.githubusercontent.com/assets/3889023/3535218/82bf50e2-07fc-11e4-8228-0e00e94e5d12.png)

### UX impressions

* In general the experience of navigating up/down with the mouse holding down the scroll control is a good enough UX
* Clicking with the mouse on the scroll to bring it to a location does not provide a consistent behavior
* Pressing the up/down (or page up/down) buttons also generates unpredictable results and is not a good UX.

### Proposed Fix

* Make the clicking on the the scroll area and pressing the up/down button behave similarly to holding down the mouse button and dragging the scroller to the requested location.