### PR TITLE
Enabled in-memory caching of rest responses

### DIFF
--- a/src/ServiceInsight.FunctionalTests/Services/FakeServiceControl.cs
+++ b/src/ServiceInsight.FunctionalTests/Services/FakeServiceControl.cs
@@ -33,11 +33,6 @@
             return new Uri(string.Format("si://{0}/api{1}", Address, message.GetURIQuery()));
         }
 
-        public bool HasSagaChanged(Guid sagaId)
-        {
-            return true;
-        }
-
         public SagaData GetSagaById(Guid sagaId)
         {
             return new SagaData();
@@ -82,7 +77,7 @@
             return Get<List<Endpoint>>("GetEndpoints");
         }
 
-        public IEnumerable<KeyValuePair<string, string>> GetMessageData(Guid messageId)
+        public IEnumerable<KeyValuePair<string, string>> GetMessageData(SagaMessage messageId)
         {
             return new List<KeyValuePair<string, string>>();
         }

--- a/src/ServiceInsight.sln.DotSettings
+++ b/src/ServiceInsight.sln.DotSettings
@@ -582,6 +582,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="T" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/VBNaming/PredefinedNamingRules/=TypesAndNamespaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>

--- a/src/ServiceInsight/Saga/SagaMessage.cs
+++ b/src/ServiceInsight/Saga/SagaMessage.cs
@@ -92,9 +92,12 @@
 
         internal void RefreshData(IServiceControl serviceControl)
         {
-            if (Data != null) return;
+            if (Data != null)
+            {
+                return;
+            }
 
-            Data = serviceControl.GetMessageData(MessageId).Select(kvp => new SagaMessageDataItem { Key = kvp.Key, Value = kvp.Value }).ToList();
+            Data = serviceControl.GetMessageData(this).Select(kvp => new SagaMessageDataItem { Key = kvp.Key, Value = kvp.Value }).ToList();
         }
     }
 

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -73,10 +73,10 @@
         public void Handle(SelectedMessageChanged @event)
         {
             var message = @event.Message;
-            RefreshSaga(message, a => true);
+            RefreshSaga(message);
         }
 
-        void RefreshSaga(StoredMessage message, Func<Guid, bool> HasChanged)
+        void RefreshSaga(StoredMessage message)
         {
             currentMessage = message;
             ShowSagaNotFoundWarning = false;
@@ -91,10 +91,7 @@
 
                 if (originatingSaga != null)
                 {
-                    if (HasChanged(originatingSaga.SagaId))
-                    {
-                        RefreshSaga(originatingSaga);
-                    }
+                    RefreshSaga(originatingSaga);
                 }
             }
         }
@@ -184,7 +181,7 @@
 
         public void RefreshSaga()
         {
-            RefreshSaga(currentMessage, serviceControl.HasSagaChanged);
+            RefreshSaga(currentMessage);
         }
 
         public SagaMessage SelectedMessage

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -34,7 +34,7 @@
         private const string SagaEndpoint = "sagas/{0}";
 
         ServiceControlConnectionProvider connection;
-        MemoryCache cache = new MemoryCache("ServiceControlReponses", new NameValueCollection(1) { { "cacheMemoryLimitMegabytes", "20" } });
+        MemoryCache cache;
         IEventAggregator eventAggregator;
         ProfilerSettings settings;
 
@@ -46,6 +46,7 @@
             this.connection = connection;
             this.eventAggregator = eventAggregator;
             settings = settingsProvider.GetSettings<ProfilerSettings>();
+            cache = new MemoryCache("ServiceControlReponses", new NameValueCollection(1) { { "cacheMemoryLimitMegabytes", settings.CacheSize.ToString() } });
         }
 
         public bool IsAlive()

--- a/src/ServiceInsight/ServiceControl/IServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/IServiceControl.cs
@@ -15,8 +15,6 @@ namespace Particular.ServiceInsight.Desktop.ServiceControl
 
         Uri CreateServiceInsightUri(StoredMessage message);
 
-        bool HasSagaChanged(Guid sagaId);
-
         SagaData GetSagaById(Guid sagaId);
 
         PagedResult<StoredMessage> Search(string searchQuery, int pageIndex = 1, string orderBy = null, bool ascending = false);
@@ -27,7 +25,7 @@ namespace Particular.ServiceInsight.Desktop.ServiceControl
 
         IEnumerable<Endpoint> GetEndpoints();
 
-        IEnumerable<KeyValuePair<string, string>> GetMessageData(Guid messageId);
+        IEnumerable<KeyValuePair<string, string>> GetMessageData(SagaMessage messageId);
 
         void LoadBody(StoredMessage message);
     }

--- a/src/ServiceInsight/ServiceControl/RestRequestWithCache.cs
+++ b/src/ServiceInsight/ServiceControl/RestRequestWithCache.cs
@@ -1,0 +1,32 @@
+namespace Particular.ServiceInsight.Desktop.ServiceControl
+{
+    using RestSharp;
+
+    public class RestRequestWithCache : RestRequest
+    {
+        public RestRequestWithCache(CacheStyle cacheStyle)
+        {
+            CacheSyle = cacheStyle;
+        }
+
+        public RestRequestWithCache(string resource, CacheStyle cacheStyle)
+            : this(resource, Method.GET, cacheStyle)
+        {
+        }
+
+        public RestRequestWithCache(string resource, Method method, CacheStyle cacheStyle = CacheStyle.None)
+            : base(resource, method)
+        {
+            CacheSyle = cacheStyle;
+        }
+
+        public CacheStyle CacheSyle { get; set; }
+
+        public enum CacheStyle
+        {
+            None,
+            Immutable,
+            IfNotModified
+        }
+    }
+}

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -250,6 +250,7 @@
     <Compile Include="ExtensionMethods\ViewModelExtensions.cs" />
     <Compile Include="LogWindow\LogMessage.cs" />
     <Compile Include="SequenceDiagram\MessageLineConverter.cs" />
+    <Compile Include="ServiceControl\RestRequestWithCache.cs" />
     <Compile Include="ValueConverters\BoolToStrokeDashArrayConverter.cs" />
     <Compile Include="SequenceDiagram\EndpointInfo.cs" />
     <Compile Include="SequenceDiagram\EndpointPositionConverter.cs" />

--- a/src/ServiceInsight/Settings/ProfilerSettings.cs
+++ b/src/ServiceInsight/Settings/ProfilerSettings.cs
@@ -8,12 +8,21 @@
     // Properties without a DisplayNameAttribute aren't automatically added to the options dialog.
     public class ProfilerSettings : PropertyChangedBase
     {
-        int autoRefresh;
+        int autoRefresh, cacheSize;
 
         public ProfilerSettings()
         {
             RecentSearchEntries = new ObservableCollection<string>();
             RecentServiceControlEntries = new ObservableCollection<string>();
+        }
+
+        [DefaultValue(20)]
+        [DisplayName("In-Memory Cache Size")]
+        [Description("Sets the maximum size to use for caching data in-memory in MB")]
+        public int CacheSize
+        {
+            get { return Math.Max(5, cacheSize); }
+            set { cacheSize = value; }
         }
 
         [DefaultValue(15)]


### PR DESCRIPTION
This PR enables the use of etags to do proper response caching.
With this change performance increases slightly (there is still work to do).

Some responses are immutable and therefore are cached permanently, this only applies to successful audited messages

