### PR TITLE
Remove old endpoints from endpoint explorer

### DIFF
--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -164,21 +164,26 @@
 
         public void RefreshData()
         {
-            if (ServiceControlRoot == null) TryReconnectToServiceControl();
-            if (ServiceControlRoot == null) return; //TODO: DO we need to check twice? Root node should have been added at this stage.
-
-            var endpoints = serviceControl.GetEndpoints();
-            if (endpoints == null) return;
-
-            foreach (var endpoint in endpoints.OrderBy(e => e.Name))
+            if (ServiceControlRoot == null)
             {
-                if (!ServiceControlRoot.EndpointExists(endpoint))
-                {
-                    ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(endpoint));
-                }
+                TryReconnectToServiceControl();
+            }
+            if (ServiceControlRoot == null)
+            {
+                return;
             }
 
-            //TODO: Remove non-existing endpoints efficiently
+            var endpoints = serviceControl.GetEndpoints();
+            if (endpoints == null)
+            {
+                return;
+            }
+
+            ServiceControlRoot.Children.Clear();
+            foreach (var endpoint in endpoints.OrderBy(e => e.Name))
+            {
+                ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(endpoint));
+            }
         }
 
         void TryReconnectToServiceControl()


### PR DESCRIPTION
Remove the endpoints that are no longer relevant (probably because messages in those Endpoints have been purged).

Fixes #168