### PR TITLE
Scaled out instance shows as one with tooltips for all the Hosts

### DIFF
--- a/src/ServiceInsight/Explorer/EndpointExplorer/AuditEndpointExplorerItem.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/AuditEndpointExplorerItem.cs
@@ -2,14 +2,16 @@
 {
     using System.Drawing;
     using global::ServiceInsight.Properties;
-    using Models;
+    using Particular.ServiceInsight.Desktop.Models;
 
     public class AuditEndpointExplorerItem : EndpointExplorerItem
     {
-        public AuditEndpointExplorerItem(Endpoint endpoint)
-            : base(endpoint)
+        public AuditEndpointExplorerItem(Endpoint endpoint, string hostNames = "") : base(endpoint)
         {
+            HostNames = hostNames;
         }
+
+        public string HostNames { get; set; }
 
         public override Bitmap Image
         {

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerView.xaml
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerView.xaml
@@ -13,7 +13,7 @@
              mc:Ignorable="d">
     <UserControl.Resources>
         <HierarchicalDataTemplate x:Key="TreeTemplate"
-                                  DataType="vm:EndpointExplorerItem"
+                                  DataType="vm:AuditEndpointExplorerItem"
                                   ItemsSource="{Binding Path=Children}">
             <Grid>
                 <Grid.ColumnDefinitions>
@@ -21,10 +21,10 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
                 <Grid.ToolTip>
-                    <ToolTip Visibility="{Binding Endpoint.Host, FallbackValue=Collapsed, Converter={StaticResource StringEmptyOrNullToVisibilityConverter}}">
+                    <ToolTip Visibility="{Binding HostNames, FallbackValue=Collapsed, Converter={StaticResource StringEmptyOrNullToVisibilityConverter}}">
                         <TextBlock>
                             <Run Text="Installed On: " />
-                            <Run Text="{Binding Endpoint.Host}" />
+                            <Run Text="{Binding HostNames}" />
                         </TextBlock>
                     </ToolTip>
                 </Grid.ToolTip>

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -3,14 +3,14 @@
     using System;
     using System.Linq;
     using Caliburn.Micro;
-    using ExtensionMethods;
+    using Particular.ServiceInsight.Desktop.ExtensionMethods;
     using Particular.ServiceInsight.Desktop.Framework;
     using Particular.ServiceInsight.Desktop.Framework.Events;
     using Particular.ServiceInsight.Desktop.Framework.Settings;
-    using ServiceControl;
-    using Settings;
-    using Shell;
-    using Startup;
+    using Particular.ServiceInsight.Desktop.ServiceControl;
+    using Particular.ServiceInsight.Desktop.Settings;
+    using Particular.ServiceInsight.Desktop.Shell;
+    using Particular.ServiceInsight.Desktop.Startup;
 
     public class EndpointExplorerViewModel : Screen,
         IHandle<RequestSelectingEndpoint>
@@ -170,9 +170,14 @@
             }
 
             ServiceControlRoot.Children.Clear();
-            foreach (var endpoint in endpoints.OrderBy(e => e.Name))
+
+            var endpointInstancesGroupedByName = endpoints.GroupBy(x => x.Name);
+            foreach (var scaledOutEndpoint in endpointInstancesGroupedByName)
             {
-                ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(endpoint));
+                var instances = scaledOutEndpoint.ToList();
+                var hostNames = instances.Select(instance => instance.HostDisplayName).ToList();
+                var tooltip = hostNames.Aggregate("", (s, s1) => s + "," + s1).Substring(1);
+                ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(instances.First(), tooltip));
             }
         }
 

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -175,7 +175,7 @@
             foreach (var scaledOutEndpoint in endpointInstancesGroupedByName)
             {
                 var instances = scaledOutEndpoint.ToList();
-                var hostNames = instances.Select(instance => instance.HostDisplayName);
+                var hostNames = instances.Select(instance => instance.HostDisplayName).Distinct();
                 var tooltip = string.Join(", ", hostNames);
                 ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(instances.First(), tooltip));
             }

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -175,8 +175,8 @@
             foreach (var scaledOutEndpoint in endpointInstancesGroupedByName)
             {
                 var instances = scaledOutEndpoint.ToList();
-                var hostNames = instances.Select(instance => instance.HostDisplayName).ToList();
-                var tooltip = hostNames.Aggregate("", (s, s1) => s + "," + s1).Substring(1);
+                var hostNames = instances.Select(instance => instance.HostDisplayName);
+                var tooltip = string.Join(", ", hostNames);
                 ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(instances.First(), tooltip));
             }
         }

--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml
@@ -114,7 +114,7 @@
                                         <Label Grid.Row="0" Grid.Column="1" Content="{Binding FullName}" Style="{StaticResource TooltipLabelStyle}" />
                                         <Label Grid.Row="1" Grid.Column="0" Content="NSB Version" Style="{StaticResource TooltipLabelStyle}" />
                                         <Label Grid.Row="1" Grid.Column="1" Content="{Binding Version}" Style="{StaticResource TooltipLabelStyle}" />
-                                        <Label Grid.Row="2" Grid.Column="0" Content="HostNames" Style="{StaticResource TooltipLabelStyle}" />
+                                        <Label Grid.Row="2" Grid.Column="0" Content="Host" Style="{StaticResource TooltipLabelStyle}" />
                                         <Label Grid.Row="2" Grid.Column="1" Content="{Binding Host}" Style="{StaticResource TooltipLabelStyle}" />
                                     </Grid>
                                 </ToolTip>

--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml
@@ -114,7 +114,7 @@
                                         <Label Grid.Row="0" Grid.Column="1" Content="{Binding FullName}" Style="{StaticResource TooltipLabelStyle}" />
                                         <Label Grid.Row="1" Grid.Column="0" Content="NSB Version" Style="{StaticResource TooltipLabelStyle}" />
                                         <Label Grid.Row="1" Grid.Column="1" Content="{Binding Version}" Style="{StaticResource TooltipLabelStyle}" />
-                                        <Label Grid.Row="2" Grid.Column="0" Content="Host" Style="{StaticResource TooltipLabelStyle}" />
+                                        <Label Grid.Row="2" Grid.Column="0" Content="HostNames" Style="{StaticResource TooltipLabelStyle}" />
                                         <Label Grid.Row="2" Grid.Column="1" Content="{Binding Host}" Style="{StaticResource TooltipLabelStyle}" />
                                     </Grid>
                                 </ToolTip>


### PR DESCRIPTION
This addresses issue [Endpoint explorer in SI hard to use when repeated endpoint name appear](https://github.com/Particular/FeatureDevelopment/issues/310)
Should `EndpointExplorerTests` be updated to reflect this?

@Particular/ServiceInsight please review
