### PR TITLE
SI throws exception when selected message ID is not a Guid

### DIFF
--- a/src/ServiceInsight/Saga/SagaMessage.cs
+++ b/src/ServiceInsight/Saga/SagaMessage.cs
@@ -16,7 +16,7 @@
 
     public class SagaMessage : PropertyChangedBase
     {
-        public Guid MessageId { get; set; }
+        public string MessageId { get; set; }
 
         public bool IsPublished { get; set; }
 

--- a/src/ServiceInsight/Saga/SagaUpdateControl.xaml.cs
+++ b/src/ServiceInsight/Saga/SagaUpdateControl.xaml.cs
@@ -7,7 +7,7 @@
     public partial class SagaUpdateControl
     {
         public static readonly RoutedEvent TimeoutClickEvent = EventManager.RegisterRoutedEvent("TimeoutClick", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(SagaUpdateControl));
-        public static readonly DependencyProperty SelectedMessageIdProperty = DependencyProperty.Register("SelectedMessageId", typeof(Guid), typeof(SagaUpdateControl), new FrameworkPropertyMetadata(Guid.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+        public static readonly DependencyProperty SelectedMessageIdProperty = DependencyProperty.Register("SelectedMessageId", typeof(string), typeof(SagaUpdateControl), new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
 
         public SagaUpdateControl()
         {
@@ -20,9 +20,9 @@
             remove { RemoveHandler(TimeoutClickEvent, value); }
         }
 
-        public Guid SelectedMessageId
+        public string SelectedMessageId
         {
-            get { return (Guid)GetValue(SelectedMessageIdProperty); }
+            get { return (string)GetValue(SelectedMessageIdProperty); }
             set { SetValue(SelectedMessageIdProperty, value); }
         }
 

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Windows.Input;
     using Caliburn.Micro;
+    using DevExpress.Utils.Text.Internal;
     using Models;
     using Particular.ServiceInsight.Desktop.ExtensionMethods;
     using Particular.ServiceInsight.Desktop.Framework;
@@ -15,7 +16,7 @@
     {
         SagaData data;
         StoredMessage currentMessage;
-        Guid selectedMessageId;
+        string selectedMessageId;
         IEventAggregator eventAggregator;
         IServiceControl serviceControl;
 
@@ -79,7 +80,7 @@
 
             RefreshSaga(message);
 
-            SelectedMessageId = Guid.Parse(message.MessageId);
+            SelectedMessageId = message.MessageId;
         }
 
         void RefreshSaga(StoredMessage message)
@@ -213,7 +214,7 @@
             RefreshSaga(currentMessage);
         }
 
-        public Guid SelectedMessageId
+        public string SelectedMessageId
         {
             get { return selectedMessageId; }
             set
@@ -237,7 +238,7 @@
             }
         }
 
-        void SetSelected(IEnumerable<SagaMessage> messages, Guid id)
+        void SetSelected(IEnumerable<SagaMessage> messages, string id)
         {
             if (messages == null)
                 return;
@@ -248,7 +249,7 @@
             }
         }
 
-        void SetSelected(SagaMessage message, Guid id)
+        void SetSelected(SagaMessage message, string id)
         {
             message.IsSelected = message.MessageId == id;
         }

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Windows.Input;
     using Caliburn.Micro;
-    using DevExpress.Utils.Text.Internal;
     using Models;
     using Particular.ServiceInsight.Desktop.ExtensionMethods;
     using Particular.ServiceInsight.Desktop.Framework;


### PR DESCRIPTION
NSB can handle messages coming from non-NSB endpoints, then transport level message ID is assigned. It doesn't have to be Guid (see failed message below that uses MSMQ id).
SI assumes that all IDs will be Guids, so when such a message is selected on the grid, SI throws exception and stops functioning.
![capture](https://cloud.githubusercontent.com/assets/7335079/8716333/384e2fca-2b90-11e5-9127-27f2da70f1e7.PNG)
