### PR TITLE
Colouring stack traces in ServiceInsight

### DIFF
--- a/src/ServiceInsight/App.xaml
+++ b/src/ServiceInsight/App.xaml
@@ -1,11 +1,11 @@
 ﻿<Application x:Class="Particular.ServiceInsight.Desktop.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"
-             xmlns:startup="clr-namespace:Particular.ServiceInsight.Desktop.Startup"
              xmlns:cnv="clr-namespace:Particular.ServiceInsight.Desktop.ValueConverters"
+             xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:startup="clr-namespace:Particular.ServiceInsight.Desktop.Startup"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
              ShutdownMode="OnMainWindowClose">
     <Application.Resources>
         <ResourceDictionary>
@@ -13,11 +13,11 @@
                 <ResourceDictionary>
                     <startup:AppBootstrapper x:Key="Bootstrapper" />
 
-                    <!--Fonts-->
+                    <!--  Fonts  -->
                     <FontFamily x:Key="MessageBodyFontFamily">Consolas</FontFamily>
                     <sys:Double x:Key="MessageBodyFontSize">12</sys:Double>
 
-                    <!-- Converters -->
+                    <!--  Converters  -->
                     <cnv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
                     <cnv:BoolToVisibilityConverter x:Key="BoolToVisibilityConverterInverted" Invert="True" />
                     <cnv:BoolToVisibilityConverter x:Key="BoolToVisibilityHiddenConverter" IsHidden="True" />
@@ -31,48 +31,48 @@
                     <cnv:TimeSpanHumanizedConverter x:Key="TimeSpanHumanizedConverter" />
                     <cnv:SmartWrapConverter x:Key="SmartWrapConverter" />
                     <cnv:CenterToolTipConverter x:Key="CenterToolTipConverter" />
-                    
-                    <!-- Colors and Brushes -->
+
+                    <!--  Colors and Brushes  -->
                     <SolidColorBrush x:Key="ControlBackgroundColor" Color="#FFCED4DF" />
                     <SolidColorBrush x:Key="WarningBrush" Color="#FFE52620" />
                     <Color x:Key="DiagramShadowColor">LightGray</Color>
                     <Color x:Key="DiagramSelectedShadowColor">Black</Color>
-                    <SolidColorBrush Color="#DDBCC7D8" x:Key="ZoomBoxBackgroundBrush" />
-                    <SolidColorBrush Color="#DDAEB7C9" x:Key="ZoomBoxBorderBrush" />
-                    <SolidColorBrush Color="#FFBCC7D8" x:Key="ZoomBoxButtonBackgroundBrush" />
+                    <SolidColorBrush x:Key="ZoomBoxBackgroundBrush" Color="#DDBCC7D8" />
+                    <SolidColorBrush x:Key="ZoomBoxBorderBrush" Color="#DDAEB7C9" />
+                    <SolidColorBrush x:Key="ZoomBoxButtonBackgroundBrush" Color="#FFBCC7D8" />
                     <LinearGradientBrush x:Key="ZoomBoxButtonOverBackgroundBrush">
-                        <GradientStop Color="#FFFFFAE9" Offset="0" />
-                        <GradientStop Color="#FFFFE8A6" Offset="1" />
+                        <GradientStop Offset="0" Color="#FFFFFAE9" />
+                        <GradientStop Offset="1" Color="#FFFFE8A6" />
                     </LinearGradientBrush>
                     <LinearGradientBrush x:Key="ZoomBoxButtonSelectedBackgroundBrush">
-                        <GradientStop Color="#FFFFFAE9" Offset="0" />
-                        <GradientStop Color="#FFFFE8A6" Offset="1" />
+                        <GradientStop Offset="0" Color="#FFFFFAE9" />
+                        <GradientStop Offset="1" Color="#FFFFE8A6" />
                     </LinearGradientBrush>
-                    <SolidColorBrush Color="#FF000000" x:Key="ZoomBoxTicksBrush" />
-                    <SolidColorBrush Color="#FFAAACA5" x:Key="ZoomBoxButtonBorderBrush" />
-                    <SolidColorBrush Color="#FFBCC7D8" x:Key="DialogBackgroundBrush" />
-                    <SolidColorBrush Color="#FF000000" x:Key="DialogForegroundBrush" />
-                    <SolidColorBrush Color="White" x:Key="DiagramNodeForegroundBrush" />
-                    <SolidColorBrush Color="#FF293955" x:Key="DiagramEdgeForegroundBrush" />
-                    <SolidColorBrush Color="#FFFFFFFF" x:Key="DiagramTooltipForegroundBrush" />
-                    <SolidColorBrush Color="#FF606060" x:Key="DiagramNodeBorderBrush" />
-                    <SolidColorBrush Color="#FF333333" x:Key="DiagramCurrentNodeBorderBrush" />
-                    <SolidColorBrush Color="#FFFF6932" x:Key="DiagramFailedNodeBackground" />
-                    <SolidColorBrush Color="#FFE52620" x:Key="DiagramRepeatedFailedNodeBackground" />
-                    <SolidColorBrush Color="#FF4C5F81" x:Key="DiagramSuccessNodeBackground" />
-                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0" x:Key="DiagramTooltipBackgroundBrush">
-                        <GradientStop Color="#CF181818" Offset="0" />
-                        <GradientStop Color="#BE1C1C1C" Offset="1" />
+                    <SolidColorBrush x:Key="ZoomBoxTicksBrush" Color="#FF000000" />
+                    <SolidColorBrush x:Key="ZoomBoxButtonBorderBrush" Color="#FFAAACA5" />
+                    <SolidColorBrush x:Key="DialogBackgroundBrush" Color="#FFBCC7D8" />
+                    <SolidColorBrush x:Key="DialogForegroundBrush" Color="#FF000000" />
+                    <SolidColorBrush x:Key="DiagramNodeForegroundBrush" Color="White" />
+                    <SolidColorBrush x:Key="DiagramEdgeForegroundBrush" Color="#FF293955" />
+                    <SolidColorBrush x:Key="DiagramTooltipForegroundBrush" Color="#FFFFFFFF" />
+                    <SolidColorBrush x:Key="DiagramNodeBorderBrush" Color="#FF606060" />
+                    <SolidColorBrush x:Key="DiagramCurrentNodeBorderBrush" Color="#FF333333" />
+                    <SolidColorBrush x:Key="DiagramFailedNodeBackground" Color="#FFFF6932" />
+                    <SolidColorBrush x:Key="DiagramRepeatedFailedNodeBackground" Color="#FFE52620" />
+                    <SolidColorBrush x:Key="DiagramSuccessNodeBackground" Color="#FF4C5F81" />
+                    <LinearGradientBrush x:Key="DiagramTooltipBackgroundBrush" StartPoint="0.5,0" EndPoint="0.5,1">
+                        <GradientStop Offset="0" Color="#CF181818" />
+                        <GradientStop Offset="1" Color="#BE1C1C1C" />
                     </LinearGradientBrush>
 
-                    <!-- Geometry -->
+                    <!--  Geometry  -->
                     <Geometry x:Key="DownArrow">M0,0 L1,0 0.5,1Z</Geometry>
                     <Geometry x:Key="UpArrow">M0,1 L1,1 0.5,0Z</Geometry>
                     <Geometry x:Key="RightArrow">M0,0 L1,0.5 0,1Z</Geometry>
                     <Geometry x:Key="LeftArrow">M0,0.5 L1,1 1,0Z</Geometry>
                     <Geometry x:Key="CloseX">M0,0 L1,1 M0,1 L1,0</Geometry>
 
-                    <!-- Fonts -->
+                    <!--  Fonts  -->
                     <FontFamily x:Key="IconFontFamily">Tahoma</FontFamily>
                     <FontWeight x:Key="IconFontWeight">Normal</FontWeight>
                     <FontFamily x:Key="MessageFontFamily">Tahoma</FontFamily>
@@ -81,7 +81,7 @@
                     <FontWeight x:Key="CaptionFontWeight">Bold</FontWeight>
                     <FontFamily x:Key="DialogFonts">Calibri</FontFamily>
 
-                    <!-- Space, Margin and Padding -->
+                    <!--  Space, Margin and Padding  -->
                     <sys:Double x:Key="NoSpacing">0</sys:Double>
                     <sys:Double x:Key="SmallSpacing">2</sys:Double>
                     <sys:Double x:Key="DefaultSpacing">4</sys:Double>
@@ -98,65 +98,74 @@
                     <sys:Double x:Key="LargeFontSize">16</sys:Double>
 
                     <Thickness x:Key="SmallMargin"
+                               Bottom="{StaticResource SmallSpacing}"
                                Left="{StaticResource SmallSpacing}"
-                               Top="{StaticResource SmallSpacing}"
                                Right="{StaticResource SmallSpacing}"
-                               Bottom="{StaticResource SmallSpacing}" />
+                               Top="{StaticResource SmallSpacing}" />
 
                     <Thickness x:Key="XX-LargeMargin"
+                               Bottom="{StaticResource XX-LargeSpacing}"
                                Left="{StaticResource XX-LargeSpacing}"
-                               Top="{StaticResource XX-LargeSpacing}"
                                Right="{StaticResource XX-LargeSpacing}"
-                               Bottom="{StaticResource XX-LargeSpacing}" />
+                               Top="{StaticResource XX-LargeSpacing}" />
 
                     <Thickness x:Key="LicenseDialogImageMargin"
+                               Bottom="{StaticResource LargeSpacing}"
                                Left="{StaticResource X-LargeSpacing}"
-                               Top="{StaticResource LargeSpacing}"
                                Right="{StaticResource SmallSpacing}"
-                               Bottom="{StaticResource LargeSpacing}" />
+                               Top="{StaticResource LargeSpacing}" />
 
                     <Thickness x:Key="LabelMargin"
+                               Bottom="{StaticResource MediumSpacing}"
                                Left="{StaticResource MediumSpacing}"
-                               Top="{StaticResource MediumSpacing}"
                                Right="{StaticResource MediumSpacing}"
-                               Bottom="{StaticResource MediumSpacing}" />
+                               Top="{StaticResource MediumSpacing}" />
 
                     <Thickness x:Key="DialogMargin"
+                               Bottom="{StaticResource DefaultDialogMargin}"
                                Left="{StaticResource DefaultDialogMargin}"
-                               Top="{StaticResource DefaultDialogMargin}"
                                Right="{StaticResource DefaultDialogMargin}"
-                               Bottom="{StaticResource DefaultDialogMargin}" />
+                               Top="{StaticResource DefaultDialogMargin}" />
 
                     <Thickness x:Key="DialogButtonMargin"
+                               Bottom="{StaticResource DefaultSpacing}"
                                Left="{StaticResource DefaultSpacing}"
-                               Top="{StaticResource NoSpacing}"
                                Right="{StaticResource DefaultSpacing}"
-                               Bottom="{StaticResource DefaultSpacing}" />
+                               Top="{StaticResource NoSpacing}" />
 
                     <Thickness x:Key="DefaultMargin"
+                               Bottom="{StaticResource ExtraLargeSpacing}"
                                Left="{StaticResource LargeSpacing}"
-                               Top="{StaticResource MediumSpacing}"
                                Right="{StaticResource LargeSpacing}"
-                               Bottom="{StaticResource ExtraLargeSpacing}" />
+                               Top="{StaticResource MediumSpacing}" />
 
                     <Thickness x:Key="ButtonMargin"
-                               Top="{StaticResource NoSpacing}"
+                               Bottom="{StaticResource NoSpacing}"
                                Left="{StaticResource DefaultSpacing}"
                                Right="{StaticResource DefaultSpacing}"
-                               Bottom="{StaticResource NoSpacing}" />
+                               Top="{StaticResource NoSpacing}" />
 
-                    <!--Effect-->
-                    <DropShadowEffect x:Key="DiagramNodeShadow" BlurRadius="1" Color="{StaticResource DiagramShadowColor}" Opacity="0.1" Direction="315" />
-                    <DropShadowEffect x:Key="DiagramSelectedNodeShadow" BlurRadius="35" Color="{StaticResource DiagramSelectedShadowColor}" Opacity="1" ShadowDepth="0" Direction="0" />
+                    <!--  Effect  -->
+                    <DropShadowEffect x:Key="DiagramNodeShadow"
+                                      BlurRadius="1"
+                                      Direction="315"
+                                      Opacity="0.1"
+                                      Color="{StaticResource DiagramShadowColor}" />
+                    <DropShadowEffect x:Key="DiagramSelectedNodeShadow"
+                                      BlurRadius="35"
+                                      Direction="0"
+                                      Opacity="1"
+                                      ShadowDepth="0"
+                                      Color="{StaticResource DiagramSelectedShadowColor}" />
 
-                    <!-- TextBlock Styles-->
+                    <!--  TextBlock Styles  -->
                     <Style x:Key="Informational" TargetType="{x:Type TextBlock}">
                         <Setter Property="FontFamily" Value="{StaticResource DialogFonts}" />
                         <Setter Property="FontSize" Value="10" />
                         <Setter Property="SnapsToDevicePixels" Value="true" />
                     </Style>
 
-                    <!-- Dialog Style -->
+                    <!--  Dialog Style  -->
                     <Style x:Key="DialogRootContainer" TargetType="{x:Type Border}">
                         <Setter Property="Background" Value="{StaticResource DialogBackgroundBrush}" />
                         <Setter Property="BorderBrush" Value="{StaticResource DialogForegroundBrush}" />
@@ -164,7 +173,7 @@
                         <Setter Property="SnapsToDevicePixels" Value="true" />
                     </Style>
 
-                    <!-- Dialog Buttons -->
+                    <!--  Dialog Buttons  -->
                     <Style x:Key="DialogButton" TargetType="{x:Type Button}">
                         <Setter Property="HorizontalAlignment" Value="Center" />
                         <Setter Property="MinWidth" Value="75" />
@@ -177,7 +186,7 @@
                         <Setter Property="Padding" Value="1" />
                     </Style>
 
-                    <!-- Checkbox -->
+                    <!--  Checkbox  -->
                     <Style x:Key="{x:Type CheckBox}" TargetType="{x:Type CheckBox}">
                         <Setter Property="VerticalAlignment" Value="Center" />
                         <Setter Property="FontFamily" Value="{StaticResource MessageFontFamily}" />
@@ -187,7 +196,7 @@
                         <Setter Property="VerticalContentAlignment" Value="Center" />
                     </Style>
 
-                    <!--Flat Button -->
+                    <!--  Flat Button  -->
                     <Style x:Key="FlatButton" TargetType="{x:Type Button}">
                         <Setter Property="BorderThickness" Value="1" />
                         <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
@@ -202,45 +211,87 @@
                                             <VisualStateGroup x:Name="CommonStates">
                                                 <VisualState x:Name="Normal">
                                                     <Storyboard>
-                                                        <ColorAnimation To="#F0F0F0" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)" Duration="0:0:0.07" />
-                                                        <ColorAnimation To="#E5E5E5" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)" Duration="0:0:0.07" />
-                                                        <ColorAnimation To="#ACACAC" Storyboard.TargetName="BrBrush" Storyboard.TargetProperty="Color" Duration="0:0:0.07" />
+                                                        <ColorAnimation Duration="0:0:0.07"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)"
+                                                                        To="#F0F0F0" />
+                                                        <ColorAnimation Duration="0:0:0.07"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                        To="#E5E5E5" />
+                                                        <ColorAnimation Duration="0:0:0.07"
+                                                                        Storyboard.TargetName="BrBrush"
+                                                                        Storyboard.TargetProperty="Color"
+                                                                        To="#ACACAC" />
                                                     </Storyboard>
                                                 </VisualState>
                                                 <VisualState x:Name="MouseOver">
                                                     <Storyboard>
-                                                        <ColorAnimation To="#F0F4F9" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)" Duration="0:0:0.07" />
-                                                        <ColorAnimation To="#E0ECF9" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)" Duration="0:0:0.07" />
-                                                        <ColorAnimation To="#7EB4EA" Storyboard.TargetName="BrBrush" Storyboard.TargetProperty="Color" Duration="0:0:0.07" />
+                                                        <ColorAnimation Duration="0:0:0.07"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)"
+                                                                        To="#F0F4F9" />
+                                                        <ColorAnimation Duration="0:0:0.07"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                        To="#E0ECF9" />
+                                                        <ColorAnimation Duration="0:0:0.07"
+                                                                        Storyboard.TargetName="BrBrush"
+                                                                        Storyboard.TargetProperty="Color"
+                                                                        To="#7EB4EA" />
                                                     </Storyboard>
                                                 </VisualState>
                                                 <VisualState x:Name="Pressed">
                                                     <Storyboard>
-                                                        <ColorAnimation To="#DBEDFD" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)" Duration="0:0:0.05" />
-                                                        <ColorAnimation To="#C4E0FC" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)" Duration="0:0:0.05" />
-                                                        <ColorAnimation To="#569DE5" Storyboard.TargetName="BrBrush" Storyboard.TargetProperty="Color" Duration="0:0:0.05" />
+                                                        <ColorAnimation Duration="0:0:0.05"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)"
+                                                                        To="#DBEDFD" />
+                                                        <ColorAnimation Duration="0:0:0.05"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                        To="#C4E0FC" />
+                                                        <ColorAnimation Duration="0:0:0.05"
+                                                                        Storyboard.TargetName="BrBrush"
+                                                                        Storyboard.TargetProperty="Color"
+                                                                        To="#569DE5" />
                                                     </Storyboard>
                                                 </VisualState>
                                                 <VisualState x:Name="Disabled">
                                                     <Storyboard>
-                                                        <ColorAnimation To="#EFEFEF" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)" Duration="0:0:0" />
-                                                        <ColorAnimation To="#EFEFEF" Storyboard.TargetName="BgBrush" Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)" Duration="0:0:0" />
-                                                        <ColorAnimation To="#D9D9D9" Storyboard.TargetName="BrBrush" Storyboard.TargetProperty="Color" Duration="0:0:0" />
+                                                        <ColorAnimation Duration="0:0:0"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[0].(GradientStop.Color)"
+                                                                        To="#EFEFEF" />
+                                                        <ColorAnimation Duration="0:0:0"
+                                                                        Storyboard.TargetName="BgBrush"
+                                                                        Storyboard.TargetProperty="(GradientBrush.GradientStops)[1].(GradientStop.Color)"
+                                                                        To="#EFEFEF" />
+                                                        <ColorAnimation Duration="0:0:0"
+                                                                        Storyboard.TargetName="BrBrush"
+                                                                        Storyboard.TargetProperty="Color"
+                                                                        To="#D9D9D9" />
                                                     </Storyboard>
                                                 </VisualState>
                                             </VisualStateGroup>
                                         </VisualStateManager.VisualStateGroups>
-                                        <Border x:Name="Chrome" BorderThickness="{TemplateBinding BorderThickness}" SnapsToDevicePixels="true">
+                                        <Border x:Name="Chrome"
+                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                SnapsToDevicePixels="true">
                                             <Border.BorderBrush>
                                                 <SolidColorBrush x:Name="BrBrush" Color="#ACACAC" />
                                             </Border.BorderBrush>
                                             <Border.Background>
-                                                <LinearGradientBrush x:Name="BgBrush" EndPoint="0,1" StartPoint="0,0">
-                                                    <GradientStop Color="#F0F0F0" Offset="0" />
-                                                    <GradientStop Color="#E5E5E5" Offset="1" />
+                                                <LinearGradientBrush x:Name="BgBrush" StartPoint="0,0" EndPoint="0,1">
+                                                    <GradientStop Offset="0" Color="#F0F0F0" />
+                                                    <GradientStop Offset="1" Color="#E5E5E5" />
                                                 </LinearGradientBrush>
                                             </Border.Background>
-                                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                              RecognizesAccessKey="True"
+                                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                                         </Border>
                                     </Grid>
                                     <ControlTemplate.Triggers>
@@ -253,23 +304,22 @@
                         </Setter>
                     </Style>
 
-                    <!--PropertyGrid DataTemplates-->
+                    <!--  PropertyGrid DataTemplates  -->
                     <DataTemplate x:Key="PropertyGridLongTextTemplate">
                         <dxe:MemoEdit Name="PART_Editor"
-                                      IsTextEditable="False"
-                                      IsReadOnly="True"
+                                      Height="22"
                                       AcceptsReturn="False"
-                                      ShowIcon="False"
-                                      TextWrapping="NoWrap"
+                                      IsReadOnly="True"
+                                      IsTextEditable="False"
                                       MemoTextWrapping="WrapWithOverflow"
                                       MemoVerticalScrollBarVisibility="Auto"
-                                      PopupWidth="500"
                                       PopupFooterButtons="Close"
-                                      Height="22" />
+                                      PopupWidth="500"
+                                      ShowIcon="False"
+                                      TextWrapping="NoWrap" />
                     </DataTemplate>
 
-                    <DataTemplate x:Key="PropertyGridEmptyTextTemplate">
-                    </DataTemplate>
+                    <DataTemplate x:Key="PropertyGridEmptyTextTemplate" />
 
                     <DataTemplate x:Key="TextEditGridColumnCellTemplate">
                         <dxe:TextEdit x:Name="PART_Editor" />
@@ -277,8 +327,8 @@
 
                     <DataTemplate x:Key="PropertyGridDateTextTemplate">
                         <dxe:TextEdit Name="PART_Editor"
-                                      IsReadOnly="True"
-                                      DisplayFormatString="{Binding Source={x:Static cnv:MessageDateTimeFormatProvider.MessageDateFormat}}" />
+                                      DisplayFormatString="{Binding Source={x:Static cnv:MessageDateTimeFormatProvider.MessageDateFormat}}"
+                                      IsReadOnly="True" />
                     </DataTemplate>
 
                     <Style x:Key="ItemsControlVirtualisedStyle" TargetType="ItemsControl">
@@ -294,13 +344,12 @@
                         <Setter Property="Template">
                             <Setter.Value>
                                 <ControlTemplate TargetType="ItemsControl">
-                                    <Border
-                                        BorderThickness="{TemplateBinding Border.BorderThickness}"
-                                        Padding="{TemplateBinding Control.Padding}"
-                                        BorderBrush="{TemplateBinding Border.BorderBrush}"
-                                        Background="{TemplateBinding Panel.Background}"
-                                        SnapsToDevicePixels="True">
-                                        <ScrollViewer Padding="{TemplateBinding Control.Padding}" Focusable="False">
+                                    <Border Background="{TemplateBinding Panel.Background}"
+                                            BorderBrush="{TemplateBinding Border.BorderBrush}"
+                                            BorderThickness="{TemplateBinding Border.BorderThickness}"
+                                            Padding="{TemplateBinding Control.Padding}"
+                                            SnapsToDevicePixels="True">
+                                        <ScrollViewer Focusable="False" Padding="{TemplateBinding Control.Padding}">
                                             <ItemsPresenter SnapsToDevicePixels="{TemplateBinding UIElement.SnapsToDevicePixels}" />
                                         </ScrollViewer>
                                     </Border>

--- a/src/ServiceInsight/App.xaml.cs
+++ b/src/ServiceInsight/App.xaml.cs
@@ -43,6 +43,9 @@
             LoggingConfig.SetupLogging();
             if (!Debugger.IsAttached)
                 Framework.ExceptionHandler.Attach();
+
+            Highlighting.Resources.RegisterHighlightings();
+
             InitializeComponent();
         }
 

--- a/src/ServiceInsight/Highlighting/Resources.cs
+++ b/src/ServiceInsight/Highlighting/Resources.cs
@@ -1,0 +1,37 @@
+﻿namespace Particular.ServiceInsight.Highlighting
+{
+    using System;
+    using System.Linq;
+    using System.Xml;
+    using ICSharpCode.AvalonEdit.Highlighting;
+
+    static class Resources
+    {
+        public static void RegisterHighlightings()
+        {
+            if (HighlightingManager.Instance.HighlightingDefinitions.ToList().Exists(p => p.Name == "StackTrace")) return;
+
+            // Load our custom highlighting definition
+            IHighlightingDefinition stackTraceHighlighting;
+            using (var s = typeof(Resources).Assembly.GetManifestResourceStream("ServiceInsight.Highlighting.StackTrace.xshd"))
+            {
+                if (s == null)
+                {
+                    throw new InvalidOperationException("Could not find embedded resource");
+                }
+
+                using (XmlReader reader = new XmlTextReader(s))
+                {
+                    stackTraceHighlighting = ICSharpCode.AvalonEdit.Highlighting.Xshd.
+                        HighlightingLoader.Load(reader, HighlightingManager.Instance);
+                }
+            }
+            // and register it in the HighlightingManager
+            HighlightingManager.Instance.RegisterHighlighting("StackTrace", new[]
+            {
+                ".trace"
+            }, stackTraceHighlighting);
+
+        }
+    }
+}

--- a/src/ServiceInsight/Highlighting/Resources.cs
+++ b/src/ServiceInsight/Highlighting/Resources.cs
@@ -5,6 +5,10 @@
     using System.Xml;
     using ICSharpCode.AvalonEdit.Highlighting;
 
+
+    /// <summary>
+    /// Registers bespoke highlighting for MvvmTextEditor
+    /// </summary>
     static class Resources
     {
         public static void RegisterHighlightings()

--- a/src/ServiceInsight/Highlighting/StackTrace.xshd
+++ b/src/ServiceInsight/Highlighting/StackTrace.xshd
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0"?>
+<SyntaxDefinition name="Custom Highlighting" xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
+	<Color name="LineNumber" foreground="Red" />
+  <Color name="MethodCall" fontWeight="bold" foreground="#008B8B" />
+  <Color name="ClassName" foreground="#2C5CB3" />
+  <Color name="FileName" fontWeight="normal" fontStyle="italic" underline="true" foreground="Blue" />
+	
+	<!-- This is the main ruleset. -->
+	<RuleSet>
+    <Rule color="MethodCall">
+      \b
+      [\d\w_&lt;&gt;]+  # an identifier
+      (?=\s*[\(\[]) # followed by ( or [
+    </Rule>
+    <Rule color="LineNumber">
+      (?!:line\s)
+      \d+
+      $
+    </Rule>
+    <Rule color="ClassName">
+      (?&lt;=at\s)
+      .+
+      (?=
+      \. # dot before mthod call
+      [\d\w_&lt;&gt;]+ # an identifier
+      (?=\s*[\(\[]) # followed by ( or [
+      )
+    </Rule>
+    <Rule color="FileName">
+      (?&lt;=\sin\s)
+      .+
+      (?=:line\s\d+)
+    </Rule>
+	</RuleSet>
+</SyntaxDefinition>

--- a/src/ServiceInsight/MessageFlow/ExceptionDetailView.xaml
+++ b/src/ServiceInsight/MessageFlow/ExceptionDetailView.xaml
@@ -1,6 +1,7 @@
 ﻿<dx:DXWindow x:Class="Particular.ServiceInsight.Desktop.MessageFlow.ExceptionDetailView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Particular.ServiceInsight.Desktop.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -33,11 +34,15 @@
             <TextBlock Grid.Row="1" Text="{Binding Path=FormattedSource}" />
             <ScrollViewer Grid.Row="2">
                 <Border BorderBrush="Black" BorderThickness="1">
-                    <TextBox DockPanel.Dock="Top"
-                             Foreground="Black"
-                             IsReadOnly="True"
-                             ScrollViewer.CanContentScroll="True"
-                             Text="{Binding Path=Exception.StackTrace}" />
+
+                    <controls:MvvmTextEditor DockPanel.Dock="Top"
+                                             FontFamily="Consolas"
+                                             FontSize="10pt"
+                                             IsReadOnly="true"
+                                             ScrollViewer.CanContentScroll="True"
+                                             SyntaxHighlighting="StackTrace"
+                                             Text="{Binding Path=Exception.StackTrace}" />
+
                 </Border>
             </ScrollViewer>
         </Grid>

--- a/src/ServiceInsight/MessageHeaders/MessageHeaderValueTemplateSelector.cs
+++ b/src/ServiceInsight/MessageHeaders/MessageHeaderValueTemplateSelector.cs
@@ -1,0 +1,31 @@
+﻿namespace Particular.ServiceInsight.Desktop.MessageHeaders
+{
+    using System.Windows;
+    using System.Windows.Controls;
+
+    public class MessageHeaderValueTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate ExceptionTemplate
+        { get; set; }
+
+        public DataTemplate TextTemplate
+        { get; set; }
+
+     
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            var obj = item as MessageHeaderKeyValue;
+
+            if (obj != null)
+            {
+                if (obj.Key.Contains("StackTrace"))
+                {
+                    return ExceptionTemplate;
+                }
+                return TextTemplate;
+            }
+            else
+                return base.SelectTemplate(item, container);
+        }
+    }
+}

--- a/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml
+++ b/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml
@@ -1,6 +1,7 @@
 ﻿<UserControl x:Class="Particular.ServiceInsight.Desktop.MessageHeaders.MessageHeadersView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Particular.ServiceInsight.Desktop.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:messageHeaders="clr-namespace:Particular.ServiceInsight.Desktop.MessageHeaders"
@@ -10,59 +11,78 @@
              mc:Ignorable="d">
     <UserControl.Resources>
         <Style x:Key="DataGridStyle" TargetType="{x:Type DataGrid}">
-            <Setter Property="BorderBrush" Value="#D6D6D6"/>
-            <Setter Property="HorizontalGridLinesBrush" Value="#D6D6D6"/>
-            <Setter Property="VerticalGridLinesBrush" Value="#D6D6D6"/>
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle}"/>
+            <Setter Property="BorderBrush" Value="#D6D6D6" />
+            <Setter Property="HorizontalGridLinesBrush" Value="#D6D6D6" />
+            <Setter Property="VerticalGridLinesBrush" Value="#D6D6D6" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="ColumnHeaderStyle" Value="{DynamicResource ColumnHeaderStyle}" />
         </Style>
-        <Style TargetType="{x:Type Thumb}" x:Key="ThumbStyle">
+        <Style x:Key="ThumbStyle" TargetType="{x:Type Thumb}">
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type Thumb}">
-                        <Rectangle Width="7" Stroke="Transparent" Cursor="SizeWE"/>
+                        <Rectangle Width="7"
+                                   Cursor="SizeWE"
+                                   Stroke="Transparent" />
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>
         </Style>
         <Style x:Key="ColumnHeaderStyle" TargetType="DataGridColumnHeader">
-            <Setter Property="FontWeight" Value="Bold"/>
+            <Setter Property="FontWeight" Value="Bold" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="{x:Type DataGridColumnHeader}">
                         <Grid>
                             <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
-                            <Border x:Name="BackgroundBorder" BorderThickness="0,0,1,1"
-                                Background="White"
-                                BorderBrush="#D6D6D6"
-                                Grid.ColumnSpan="2" />
-                            <ContentPresenter Grid.Column="0" Margin="6,3,6,3" VerticalAlignment="Center"/>
-                            <Path x:Name="SortArrow" Visibility="Collapsed" Data="M 0,0 L 1,0 0.5,1 z" Stretch="Fill"
-                             Grid.Column="1" Width="8" Height="6" Fill="#666666" Margin="0,0,8,0"
-                              VerticalAlignment="Center" RenderTransformOrigin="0.5, 0.4"/>
-                            <Thumb Grid.Column="0" x:Name="PART_LeftHeaderGripper" HorizontalAlignment="Left" Style="{StaticResource ThumbStyle}"/>
-                            <Thumb x:Name="PART_RightHeaderGripper" Grid.Column="1" HorizontalAlignment="Right" Style="{StaticResource ThumbStyle}"/>
+                            <Border x:Name="BackgroundBorder"
+                                    Grid.ColumnSpan="2"
+                                    Background="White"
+                                    BorderBrush="#D6D6D6"
+                                    BorderThickness="0,0,1,1" />
+                            <ContentPresenter Grid.Column="0"
+                                              Margin="6,3,6,3"
+                                              VerticalAlignment="Center" />
+                            <Thumb x:Name="PART_LeftHeaderGripper"
+                                   Grid.Column="0"
+                                   HorizontalAlignment="Left"
+                                   Style="{StaticResource ThumbStyle}" />
+                            <Path x:Name="SortArrow"
+                                  Grid.Column="1"
+                                  Width="8"
+                                  Height="6"
+                                  Margin="0,0,8,0"
+                                  VerticalAlignment="Center"
+                                  Data="M 0,0 L 1,0 0.5,1 z"
+                                  Fill="#666666"
+                                  RenderTransformOrigin="0.5, 0.4"
+                                  Stretch="Fill"
+                                  Visibility="Collapsed" />
+                            <Thumb x:Name="PART_RightHeaderGripper"
+                                   Grid.Column="1"
+                                   HorizontalAlignment="Right"
+                                   Style="{StaticResource ThumbStyle}" />
                         </Grid>
                         <ControlTemplate.Triggers>
                             <Trigger Property="IsMouseOver" Value="True">
-                                <Setter TargetName="BackgroundBorder" Property="Background" Value="#F0F0F0"/>
+                                <Setter TargetName="BackgroundBorder" Property="Background" Value="#F0F0F0" />
                             </Trigger>
                             <Trigger Property="SortDirection" Value="Ascending">
-                                <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                                 <Setter TargetName="SortArrow" Property="RenderTransform">
                                     <Setter.Value>
-                                        <RotateTransform Angle="180"/>
+                                        <RotateTransform Angle="180" />
                                     </Setter.Value>
                                 </Setter>
                             </Trigger>
                             <Trigger Property="SortDirection" Value="Descending">
-                                <Setter TargetName="SortArrow" Property="Visibility" Value="Visible"/>
+                                <Setter TargetName="SortArrow" Property="Visibility" Value="Visible" />
                             </Trigger>
                             <Trigger Property="DisplayIndex" Value="0">
-                                <Setter TargetName="PART_LeftHeaderGripper" Property="Visibility" Value="Collapsed"/>
+                                <Setter TargetName="PART_LeftHeaderGripper" Property="Visibility" Value="Collapsed" />
                             </Trigger>
                         </ControlTemplate.Triggers>
                     </ControlTemplate>
@@ -71,22 +91,55 @@
             <!--<Setter Property="Background" Value="White"/>-->
             <Style.Triggers>
                 <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#F0F0F0"/>
+                    <Setter Property="Background" Value="#F0F0F0" />
                 </Trigger>
             </Style.Triggers>
         </Style>
     </UserControl.Resources>
     <Grid>
-        <DataGrid Name="gridView" VerticalScrollBarVisibility="Visible" HeadersVisibility="Column" ScrollViewer.CanContentScroll="False" EnableRowVirtualization="False" Style="{StaticResource DataGridStyle}" ItemsSource="{Binding KeyValues}" IsReadOnly="True" AutoGenerateColumns="False" CanUserSortColumns="True" CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="False" CanUserResizeColumns="True" CanUserResizeRows="False" >
+        <Grid.Resources>
+            <DataTemplate x:Key="TextTemplate">
+                <TextBlock Text="{Binding Value}" />
+            </DataTemplate>
+            <DataTemplate x:Key="ExceptionTemplate">
+                <controls:MvvmTextEditor FontFamily="Consolas"
+                                         FontSize="10pt"
+                                         IsReadOnly="true"
+                                         SyntaxHighlighting="StackTrace"
+                                         Text="{Binding Value}" />
+            </DataTemplate>
+        </Grid.Resources>
+        <DataGrid Name="gridView"
+                  AutoGenerateColumns="False"
+                  CanUserAddRows="False"
+                  CanUserDeleteRows="False"
+                  CanUserReorderColumns="False"
+                  CanUserResizeColumns="True"
+                  CanUserResizeRows="False"
+                  CanUserSortColumns="True"
+                  EnableRowVirtualization="False"
+                  HeadersVisibility="Column"
+                  IsReadOnly="True"
+                  ItemsSource="{Binding KeyValues}"
+                  ScrollViewer.CanContentScroll="False"
+                  Style="{StaticResource DataGridStyle}"
+                  VerticalScrollBarVisibility="Visible">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="Key"  Binding="{Binding Key}"/>
-                <DataGridTextColumn Header="Value" Binding="{Binding Value}" />
+                <DataGridTextColumn Binding="{Binding Key}" Header="Key" />
+                <!--<DataGridTextColumn Header="Value"  Binding="{Binding Value}"/>-->
+                <DataGridTemplateColumn ClipboardContentBinding="{Binding Value}" Header="Value">
+                    <DataGridTemplateColumn.CellTemplateSelector>
+                        <messageHeaders:MessageHeaderValueTemplateSelector ExceptionTemplate="{StaticResource ExceptionTemplate}" TextTemplate="{StaticResource TextTemplate}" />
+                    </DataGridTemplateColumn.CellTemplateSelector>
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
             <DataGrid.ContextMenu>
                 <ContextMenu>
-                    <MenuItem Header="Copy to Clipboard" Command="ApplicationCommands.Copy" >
+                    <MenuItem Command="ApplicationCommands.Copy" Header="Copy to Clipboard">
                         <MenuItem.Icon>
-                            <Image Width="16" Height="16" Source="/Images/Copy.png" />
+                            <Image Width="16"
+                                   Height="16"
+                                   Source="/Images/Copy.png" />
                         </MenuItem.Icon>
                     </MenuItem>
                 </ContextMenu>

--- a/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml.cs
+++ b/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml.cs
@@ -1,9 +1,12 @@
 ﻿namespace Particular.ServiceInsight.Desktop.MessageHeaders
 {
+
     public partial class MessageHeadersView
     {
         public MessageHeadersView()
         {
+            Highlighting.Resources.RegisterHighlightings();
+
             InitializeComponent();
         }
     }

--- a/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml.cs
+++ b/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml.cs
@@ -5,8 +5,6 @@
     {
         public MessageHeadersView()
         {
-            Highlighting.Resources.RegisterHighlightings();
-
             InitializeComponent();
         }
     }

--- a/src/ServiceInsight/MessageProperties/MessagePropertiesView.xaml
+++ b/src/ServiceInsight/MessageProperties/MessagePropertiesView.xaml
@@ -1,23 +1,24 @@
 ﻿<UserControl x:Class="Particular.ServiceInsight.Desktop.MessageProperties.MessagePropertiesView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:dxprg="http://schemas.devexpress.com/winfx/2008/xaml/propertygrid"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dxb="http://schemas.devexpress.com/winfx/2008/xaml/bars"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="300">
+             xmlns:dxprg="http://schemas.devexpress.com/winfx/2008/xaml/propertygrid"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="300"
+             d:DesignWidth="300"
+             mc:Ignorable="d">
 
-    
-    <dxprg:PropertyGridControl SelectedObject="{Binding}" 
-                               AllowInstanceInitializer="False"
-                               ShowProperties="WithPropertyDefinitions"
-                               SortMode="Definitions"
+
+    <dxprg:PropertyGridControl AllowInstanceInitializer="False"
+                               ExpandCategoriesWhenSelectedObjectChanged="True"
+                               SelectedObject="{Binding}"
+                               ShowCategories="False"
                                ShowDescriptionIn="Panel"
-                               ExpandCategoriesWhenSelectedObjectChanged="True" 
-                               ShowCategories="False" 
-                               ShowToolPanel="False">
-        <dxprg:PropertyDefinition Path="General" CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}">
+                               ShowProperties="WithPropertyDefinitions"
+                               ShowToolPanel="False"
+                               SortMode="Definitions">
+        <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}" Path="General">
             <dxprg:PropertyDefinition Path="Version" />
             <dxprg:PropertyDefinition Path="EnclosedMessageTypes" />
             <dxprg:PropertyDefinition Path="MessageId" />
@@ -25,29 +26,29 @@
             <dxprg:PropertyDefinition Path="ContentType" />
             <dxprg:PropertyDefinition Path="IsDeferedMessage" />
             <dxprg:PropertyDefinition Path="ConversationId" />
-            <dxprg:PropertyDefinition Path="HeaderContent" CellTemplate="{StaticResource PropertyGridLongTextTemplate}" />
+            <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridLongTextTemplate}" Path="HeaderContent" />
         </dxprg:PropertyDefinition>
-        <dxprg:PropertyDefinition Path="Performance" CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}">
-            <dxprg:PropertyDefinition Path="TimeSent" CellTemplate="{StaticResource PropertyGridDateTextTemplate}" />
-            <dxprg:PropertyDefinition Path="ProcessingStarted" CellTemplate="{StaticResource PropertyGridDateTextTemplate}" />
-            <dxprg:PropertyDefinition Path="ProcessingEnded" CellTemplate="{StaticResource PropertyGridDateTextTemplate}" />
+        <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}" Path="Performance">
+            <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridDateTextTemplate}" Path="TimeSent" />
+            <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridDateTextTemplate}" Path="ProcessingStarted" />
+            <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridDateTextTemplate}" Path="ProcessingEnded" />
             <dxprg:PropertyDefinition Path="ProcessingTime" />
             <dxprg:PropertyDefinition Path="DeliveryTime" />
             <dxprg:PropertyDefinition Path="CriticalTime" />
         </dxprg:PropertyDefinition>
-        <dxprg:PropertyDefinition Path="Errors" CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}">
-            <dxprg:PropertyDefinition Path="ExceptionInfo" CellTemplate="{StaticResource PropertyGridLongTextTemplate}" />
+        <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}" Path="Errors">
+            <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridLongTextTemplate}" Path="ExceptionInfo" />
             <dxprg:PropertyDefinition Path="FailedQueue" />
             <dxprg:PropertyDefinition Path="TimeOfFailure" />
         </dxprg:PropertyDefinition>
-        <dxprg:PropertyDefinition Path="Gateway" CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}">
+        <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}" Path="Gateway">
             <dxprg:PropertyDefinition Path="From" />
             <dxprg:PropertyDefinition Path="To" />
             <dxprg:PropertyDefinition Path="DestinationSites" />
             <dxprg:PropertyDefinition Path="OriginatingSite" />
             <dxprg:PropertyDefinition Path="RouteTo" />
         </dxprg:PropertyDefinition>
-        <dxprg:PropertyDefinition Path="Saga" CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}">
+        <dxprg:PropertyDefinition CellTemplate="{StaticResource PropertyGridEmptyTextTemplate}" Path="Saga">
             <dxprg:PropertyDefinition Path="SagaType" />
             <dxprg:PropertyDefinition Path="SagaDataType" />
             <dxprg:PropertyDefinition Path="OriginatingSagaId" />

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -48,6 +48,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <EmbeddedResource Include="Highlighting\StackTrace.xshd" />
     <None Include="packages.config" />
     <None Include="FodyWeavers.xml" />
     <Reference Include="Anotar.Serilog">
@@ -249,6 +250,7 @@
     <Compile Include="Framework\Attachments\Attachment.cs" />
     <Compile Include="Framework\Behaviors\DropDownButtonBehavior.cs" />
     <Compile Include="Framework\TypeHumanizer.cs" />
+    <Compile Include="Highlighting\Resources.cs" />
     <Compile Include="LogWindow\LoggingRichTextBoxBehavior.cs" />
     <Compile Include="Framework\DefaultClipboard.cs" />
     <Compile Include="Framework\Behaviors\BindableSelectedItemBehavior.cs" />
@@ -265,6 +267,7 @@
     <Compile Include="Framework\Rx\RxViewAware.cs" />
     <Compile Include="ExtensionMethods\ViewModelExtensions.cs" />
     <Compile Include="LogWindow\LogMessage.cs" />
+    <Compile Include="MessageHeaders\MessageHeaderValueTemplateSelector.cs" />
     <Compile Include="MessageViewers\HexViewer\HexContentLine.cs" />
     <Compile Include="MessageViewers\JsonViewer\BraceFoldingStrategy.cs" />
     <Compile Include="SequenceDiagram\MessageLineConverter.cs" />

--- a/src/ServiceInsight/Shell/Shell.xaml
+++ b/src/ServiceInsight/Shell/Shell.xaml
@@ -231,7 +231,7 @@
 
         <!--  Dock Windows  -->
         <Grid>
-            <dxd:DockLayoutManager x:Name="DockManager" AutomationProperties.AutomationId="DockManager" >
+            <dxd:DockLayoutManager x:Name="DockManager" AutomationProperties.AutomationId="DockManager">
                 <dxd:DockLayoutManager.AutoHideGroups>
 
                     <dxd:AutoHideGroup AutoHideSize="300, 200"
@@ -250,8 +250,9 @@
                 </dxd:DockLayoutManager.AutoHideGroups>
 
                 <dxd:LayoutGroup AutomationProperties.AutomationId="ContentGroup">
-                    <dxd:LayoutGroup ItemWidth="4*" Orientation="Vertical" 
-                                     AutomationProperties.AutomationId="RightSideContentGroup">
+                    <dxd:LayoutGroup AutomationProperties.AutomationId="RightSideContentGroup"
+                                     ItemWidth="4*"
+                                     Orientation="Vertical">
                         <dxd:LayoutPanel x:Name="Messages"
                                          AllowClose="False"
                                          AllowFloat="False"
@@ -262,8 +263,9 @@
                             <ContentControl cal:View.Model="{Binding Messages}" />
                         </dxd:LayoutPanel>
 
-                        <dxd:LayoutGroup ItemHeight="2*" Orientation="Horizontal" 
-                                         AutomationProperties.AutomationId="RightBottomContentGroup"> 
+                        <dxd:LayoutGroup AutomationProperties.AutomationId="RightBottomContentGroup"
+                                         ItemHeight="2*"
+                                         Orientation="Horizontal">
                             <dxd:TabbedGroup x:Name="MainTabbedView"
                                              AllowClose="False"
                                              AllowFloat="False"
@@ -311,8 +313,8 @@
                                                  AutomationProperties.AutomationId="MessageBody"
                                                  Caption="Body"
                                                  CaptionImage="/Images/Document.png"
-                                                 ShowBorder="False"
-                                                 IsVisibleChanged="MessageBody_OnIsVisibleChanged">
+                                                 IsVisibleChanged="MessageBody_OnIsVisibleChanged"
+                                                 ShowBorder="False">
                                     <ContentControl cal:View.Model="{Binding MessageBody}" />
                                 </dxd:LayoutPanel>
 


### PR DESCRIPTION
As a developer reading Stack traces is a daily job, so with this new release of ServiceInsight we have spiced things up and added some colour to the boring black while Stack traces.
Hopefully this will aid you in your quest to identify and kill those nasty bugs.

Stack traces are now colored to help you pick out key data at a glance.


![capture](https://cloud.githubusercontent.com/assets/1644481/9028836/97787018-39c9-11e5-8290-48fb62d82eac.PNG)
![capture2](https://cloud.githubusercontent.com/assets/1644481/9028837/9b06c14e-39c9-11e5-9258-821de700653d.PNG)

