### PR TITLE
Handle null header data in diagrams and main grid

### DIFF
--- a/src/ServiceInsight/App.xaml
+++ b/src/ServiceInsight/App.xaml
@@ -272,7 +272,7 @@
                     </DataTemplate>
 
                     <DataTemplate x:Key="TextEditGridColumnCellTemplate">
-                        <dxe:TextEdit x:Name="PART_Editor" />
+                        <dxe:TextEdit x:Name="PART_Editor" NullText="Unknown"/>
                     </DataTemplate>
 
                     <DataTemplate x:Key="PropertyGridDateTextTemplate">

--- a/src/ServiceInsight/App.xaml
+++ b/src/ServiceInsight/App.xaml
@@ -6,6 +6,7 @@
              xmlns:startup="clr-namespace:Particular.ServiceInsight.Desktop.Startup"
              xmlns:cnv="clr-namespace:Particular.ServiceInsight.Desktop.ValueConverters"
              xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+             xmlns:dxet="http://schemas.devexpress.com/winfx/2008/xaml/editors/themekeys"
              ShutdownMode="OnMainWindowClose">
     <Application.Resources>
         <ResourceDictionary>
@@ -31,7 +32,7 @@
                     <cnv:TimeSpanHumanizedConverter x:Key="TimeSpanHumanizedConverter" />
                     <cnv:SmartWrapConverter x:Key="SmartWrapConverter" />
                     <cnv:CenterToolTipConverter x:Key="CenterToolTipConverter" />
-                    
+
                     <!-- Colors and Brushes -->
                     <SolidColorBrush x:Key="ControlBackgroundColor" Color="#FFCED4DF" />
                     <SolidColorBrush x:Key="WarningBrush" Color="#FFE52620" />
@@ -272,7 +273,10 @@
                     </DataTemplate>
 
                     <DataTemplate x:Key="TextEditGridColumnCellTemplate">
-                        <dxe:TextEdit x:Name="PART_Editor" NullText="Unknown"/>
+                        <DataTemplate.Resources>
+                            <SolidColorBrush x:Key="{dxet:TextEditThemeKey ResourceKey=NullTextForeground, IsThemeIndependent=True}" Color="#3c3c3c" />
+                        </DataTemplate.Resources>
+                        <dxe:TextEdit x:Name="PART_Editor" NullText="Unknown" />
                     </DataTemplate>
 
                     <DataTemplate x:Key="PropertyGridDateTextTemplate">

--- a/src/ServiceInsight/Framework/TypeHumanizer.cs
+++ b/src/ServiceInsight/Framework/TypeHumanizer.cs
@@ -7,7 +7,7 @@
         public static string ToName(string type)
         {
             if (string.IsNullOrEmpty(type))
-                return string.Empty;
+                return null;
 
             var clazz = type.Split(',').First();
             var objectName = clazz.Split('.').Last();

--- a/src/ServiceInsight/MessageFlow/MessageFlowView.xaml
+++ b/src/ServiceInsight/MessageFlow/MessageFlowView.xaml
@@ -116,7 +116,7 @@
                                                   Fill="#FF000000"
                                                   Stretch="Fill" />
                                         </StackPanel>
-                                        <TextBlock Style="{StaticResource TimeSentText}" Text="{Binding TimeSent}" />
+                                        <TextBlock Style="{StaticResource TimeSentText}" Text="{Binding TimeSent, TargetNullValue='TimeSent value unknown'}" />
                                     </StackPanel>
                                 </ControlTemplate>
                             </Setter.Value>

--- a/src/ServiceInsight/MessageFlow/MessageFlowView.xaml
+++ b/src/ServiceInsight/MessageFlow/MessageFlowView.xaml
@@ -105,7 +105,7 @@
                                                        FontSize="14px"
                                                        FontWeight="Bold"
                                                        Style="{StaticResource MessageTypeText}"
-                                                       Text="{Binding Message.FriendlyMessageType}"
+                                                       Text="{Binding Message.FriendlyMessageType, TargetNullValue='MessageType value unknown'}"
                                                        ToolTip="{Binding Message.FriendlyMessageType}" />
 
                                             <Path x:Name="ChevronDown"

--- a/src/ServiceInsight/MessageList/MessageListView.xaml.cs
+++ b/src/ServiceInsight/MessageList/MessageListView.xaml.cs
@@ -66,6 +66,10 @@
             {
                 e.DisplayText = ((TimeSpan)e.Value).SubmillisecondHumanize();
             }
+            if (e.Value is DateTime? && (DateTime?)e.Value == DateTime.MinValue)
+            {
+                e.DisplayText = "Unknown";
+            }
         }
 
         void Grid_OnStartSorting(object sender, RoutedEventArgs e)

--- a/src/ServiceInsight/Saga/SagaMessage.cs
+++ b/src/ServiceInsight/Saga/SagaMessage.cs
@@ -53,7 +53,19 @@
             get { return TypeHumanizer.ToName(MessageType); }
         }
 
-        public DateTime TimeSent { get; set; }
+        DateTime? timeSent;
+        public DateTime? TimeSent
+        {
+            get { return timeSent; }
+            set
+            {
+                if (value == DateTime.MinValue)
+                    timeSent = null;
+                else
+                    timeSent = value;
+
+            }
+        }
 
         public string ReceivingEndpoint { get; set; }
 

--- a/src/ServiceInsight/Saga/SagaUpdateControl.xaml
+++ b/src/ServiceInsight/Saga/SagaUpdateControl.xaml
@@ -246,7 +246,7 @@
                                 <TextBlock FontSize="14px"
                                            FontWeight="Bold"
                                            Text="{Binding MessageFriendlyTypeName}" />
-                                <TextBlock FontSize="14px" Text="{Binding TimeSent}" />
+                                <TextBlock FontSize="14px" Text="{Binding TimeSent, TargetNullValue='TimeSent value unknown'}" />
                             </StackPanel>
                         </Grid>
                     </Border>


### PR DESCRIPTION
List of changes:
- Display `TimeSent value unknown` in flow diagram and saga view diagram, when `TimeSent` is null or `DateTime.Min`.
- Display `Unknown` for TimeSent in messages grid, if it's null or `DateTime.Min`.
- Display `Unknown` for message type in flow diagram when message type is null.

Here is what it looks like after these changes:
![image](https://cloud.githubusercontent.com/assets/122651/9078164/62bc23dc-3b7d-11e5-9ab7-405d7b24dc61.png)





