### PR TITLE
Default to Windows Credentials - #493

### DIFF
--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -207,7 +207,10 @@
 
         IRestClient CreateClient(string baseUrl = null)
         {
-            var client = new RestClient(baseUrl ?? connection.Url);
+            var client = new RestClient(baseUrl ?? connection.Url)
+            {
+                Authenticator = new NtlmAuthenticator()
+            };
             var deserializer = new JsonMessageDeserializer { DateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.FFFFFFFK" };
             var xdeserializer = new XmlDeserializer();
             client.ClearHandlers();


### PR DESCRIPTION
This change enabling Windows Credentials by default on the REST calls made by ServiceInsight.

ServiceControl does not use Windows Authentication natively but it can be implemented by
following this [procedure] (http://docs.particular.net/servicepulse/install-servicepulse-in-iis) to proxy it through IIS.  Enabling the Windows credentials will enable ServiceInsight to work with that scenario.  
This change has no impact on ServiceInsight when the REST calls are made directly to ServiceControl so there is no compatibly issue with current behavior.








