### PR TITLE
[WIP] Export SequenceDiagram to image

### DIFF
--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml
@@ -78,15 +78,30 @@
 
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition Height="35" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
+        <Border BorderBrush="#EFEFF2" BorderThickness="0 0 0 2">
+            <StackPanel Margin="5" Orientation="Horizontal">
+                <Button Click="ExportToPng">
+                    <StackPanel Orientation="Horizontal">
+                        <Image Margin="0,0,5,0"
+                               VerticalAlignment="Center"
+                               Source="/Images/DiagramEndpointIcon.png" />
+                        <TextBlock VerticalAlignment="Center" Text="Export to png" />
+                    </StackPanel>
+                </Button>
+            </StackPanel>
+        </Border>
+
         <ScrollViewer Name="ScrollViewer_Header"
                       HorizontalAlignment="Left"
                       HorizontalScrollBarVisibility="Hidden"
-                      VerticalScrollBarVisibility="Disabled">
-            <ItemsControl ItemsSource="{Binding Endpoints}"
+                      VerticalScrollBarVisibility="Disabled" 
+                      Grid.Row="1">
+            <ItemsControl Name="ScrollViewer_Header_Content" ItemsSource="{Binding Endpoints}"
                           Style="{StaticResource HorizontalItemsControlStyle}"
                           dd:DragDrop.IsDragSource="True"
                           dd:DragDrop.IsDropTarget="True">
@@ -155,10 +170,10 @@
         </ScrollViewer>
 
         <ScrollViewer Name="ScrollViewer_Body"
-                      Grid.Row="1"
+                      Grid.Row="2"
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
-            <Grid>
+            <Grid Name="ScrollViewer_Body_Content">
                 <ItemsControl ItemsSource="{Binding Endpoints}" Style="{StaticResource HorizontalItemsControlStyle}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>

--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml.cs
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml.cs
@@ -24,11 +24,13 @@
 
         void ExportToPng(object sender, RoutedEventArgs e)
         {
+            var scalingRatioX = ScrollViewer_Body_Content.ActualWidth/ScrollViewer_Body.ViewportWidth;
+            var scalingRatioY = ScrollViewer_Body_Content.ActualHeight/ScrollViewer_Body.ViewportHeight;
             var dpi = 96;
             var rtb = new RenderTargetBitmap(
-                (int)ScrollViewer_Body_Content.ActualWidth,
-                (int)ScrollViewer_Header_Content.ActualHeight + (int)ScrollViewer_Body_Content.ActualHeight,
-                dpi, dpi,
+                (int)(ScrollViewer_Body_Content.ActualWidth * scalingRatioX),
+                (int)(ScrollViewer_Header_Content.ActualHeight * scalingRatioY + ScrollViewer_Body_Content.ActualHeight * scalingRatioY),
+                dpi * scalingRatioX, dpi * scalingRatioY,
                 PixelFormats.Pbgra32 // pixelformat 
                 );
 

--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml.cs
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml.cs
@@ -6,6 +6,7 @@
     using System.Windows.Controls;
     using System.Windows.Media;
     using System.Windows.Media.Imaging;
+    using Microsoft.Win32;
 
     public partial class SequenceDiagramView
     {
@@ -47,7 +48,16 @@
             }
             rtb.Render(drawingVisual);
 
-            SaveRTBAsPNG(rtb, "C:\\SequenceDiagram1.png");
+            var saveFileDialog = new SaveFileDialog
+            {
+                AddExtension = true,
+                DefaultExt = ".png",
+                FileName = "sequencediagram.png"
+            };
+            if (saveFileDialog.ShowDialog() == true)
+            {
+                SaveRTBAsPNG(rtb, saveFileDialog.FileName);
+            }
         }
 
         private static void SaveRTBAsPNG(RenderTargetBitmap bmp, string filename)

--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml.cs
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramView.xaml.cs
@@ -1,6 +1,11 @@
 ﻿namespace Particular.ServiceInsight.Desktop.SequenceDiagram
 {
+    using System;
+    using System.IO;
+    using System.Windows;
     using System.Windows.Controls;
+    using System.Windows.Media;
+    using System.Windows.Media.Imaging;
 
     public partial class SequenceDiagramView
     {
@@ -15,6 +20,43 @@
         {
             ScrollViewer_Header.Width = e.ViewportWidth;
             ScrollViewer_Header.ScrollToHorizontalOffset(e.HorizontalOffset);
+        }
+
+        void ExportToPng(object sender, RoutedEventArgs e)
+        {
+            var dpi = 96;
+            var rtb = new RenderTargetBitmap(
+                (int)ScrollViewer_Body_Content.ActualWidth,
+                (int)ScrollViewer_Header_Content.ActualHeight + (int)ScrollViewer_Body_Content.ActualHeight,
+                dpi, dpi,
+                PixelFormats.Pbgra32 // pixelformat 
+                );
+
+            var offset = Math.Abs(ScrollViewer_Body_Content.ActualWidth - ScrollViewer_Header_Content.ActualHeight) / 2;
+            VisualBrush sourceBrush = new VisualBrush(ScrollViewer_Header_Content);
+            VisualBrush sourceBrush2 = new VisualBrush(ScrollViewer_Body_Content);
+            DrawingVisual drawingVisual = new DrawingVisual();
+            DrawingContext drawingContext = drawingVisual.RenderOpen();
+
+            using (drawingContext)
+            {
+                drawingContext.DrawRectangle(sourceBrush, null, new Rect(new Point(0, 0), new Size(ScrollViewer_Body_Content.ActualWidth, ScrollViewer_Header_Content.ActualHeight)));
+                drawingContext.DrawRectangle(sourceBrush2, null, new Rect(new Point(0, 69.88), new Size(ScrollViewer_Body_Content.ActualWidth, ScrollViewer_Body_Content.ActualHeight)));
+            }
+            rtb.Render(drawingVisual);
+
+            SaveRTBAsPNG(rtb, "C:\\SequenceDiagram1.png");
+        }
+
+        private static void SaveRTBAsPNG(RenderTargetBitmap bmp, string filename)
+        {
+            var enc = new PngBitmapEncoder();
+            enc.Frames.Add(BitmapFrame.Create(bmp));
+
+            using (var stm = File.Create(filename))
+            {
+                enc.Save(stm);
+            }
         }
     }
 }


### PR DESCRIPTION
Task force: @weralabaj @johnsimons @HEskandari 

Related to: https://github.com/Particular/PlatformDevelopment/issues/286. Issue 286 has become Epic and may take a long time to resolve. This issue is to deliver short term benefit to users struggling with buggy-ness of the Sequence Diagram.

### Description

Exports a diagram to image.

See sample flow below (flow diagram included to visualize what percentage of the whole conversation is visible at once on SequenceDiagram):
![example](https://cloud.githubusercontent.com/assets/7335079/9657828/d129d746-5244-11e5-85db-e490109ec154.png)

The purpose of this task is to determine and implement the best solution to address this problem. The proposed approach is adding exporting to image functionality.

### Customer Communication
*Standard announcement and mention in a blog post on platform update.*

Until now you had to bring your manager to your screen to explain a fault. Now you can take your screen to your manager by using our new export as image function.

Our Customers have been asking for ways to take snapshots of the sequence diagram so they can distribute it easily to project stakeholders. We have implemented an easy way to export the diagram to an image.

### Impact Assessment

Seeing the whole diagram at once saves time and requires less mental to understand how the system works. This is especially important during **troubleshooting**, but is also useful during **implementation** or for **reviewing system runtime behaviour**.

Given that FlowDiagram works well even for large flows, customers are not likely to start using SequenceDiagram or keep using it. Instead they'll just stick to FlowDiagram. Therefore the overall impact is Medium.

### Alignment with Vision

Improves [Troubleshooting](https://github.com/Particular/Vision/issues/18) and [Coding](https://github.com/Particular/Vision/issues/20) experiences for [Developers](https://github.com/Particular/Vision/issues/15).

### Plan of Attack

#### Implement
- [ ] Implement "export diagram to image" feature (preferred); export to PDF (print-friendly solution)
- [ ] or mplement full screen view

#### Document
- [ ] Send standard announcement
- [ ] Mention in a blog post (September platform update).
- [ ] Update current [SI overview](http://docs.particular.net/serviceinsight/getting-started-overview) -  add section on SequenceDiagram

#### Done
- [ ] Ready Customer Communications

Related to Particular/PlatformDevelopment#286