### PR TITLE
RestoreLayout NullRef fix

### DIFF
--- a/src/ServiceInsight/Framework/Settings/SettingsProvider.cs
+++ b/src/ServiceInsight/Framework/Settings/SettingsProvider.cs
@@ -21,7 +21,9 @@ namespace ServiceInsight.Framework.Settings
             {
                 if (settingsRepository.HasSettings(GetKey<T>()))
                 {
-                    return LoadSettings<T>(ReadSettingMetadata<T>());
+                    var settings = LoadSettings<T>(ReadSettingMetadata<T>());
+                    if (!Equals(settings, default(T)))
+                        return settings;
                 }
                 return GetDefaultSettings<T>();
             }

--- a/src/ServiceInsight/Shell/Shell.xaml.cs
+++ b/src/ServiceInsight/Shell/Shell.xaml.cs
@@ -79,7 +79,7 @@
 
         public void OnRestoreLayout(ISettingsProvider settingsProvider)
         {
-            var layoutSetting = settingsProvider.GetSettings<ShellLayoutSettings>();
+            var layoutSetting = settingsProvider.GetSettings<ShellLayoutSettings>() ?? new ShellLayoutSettings();
             var currentLayoutVersion = GetCurrentLayoutVersion();
 
             if (layoutSetting.LayoutVersion == currentLayoutVersion)

--- a/src/ServiceInsight/Shell/Shell.xaml.cs
+++ b/src/ServiceInsight/Shell/Shell.xaml.cs
@@ -56,7 +56,7 @@
 
         public void OnSaveLayout(ISettingsProvider settingProvider)
         {
-            var layoutSetting = settingProvider.GetSettings<ShellLayoutSettings>() ?? new ShellLayoutSettings();
+            var layoutSetting = settingProvider.GetSettings<ShellLayoutSettings>();
 
             if (!layoutSetting.ResetLayout)
             {
@@ -79,7 +79,7 @@
 
         public void OnRestoreLayout(ISettingsProvider settingsProvider)
         {
-            var layoutSetting = settingsProvider.GetSettings<ShellLayoutSettings>() ?? new ShellLayoutSettings();
+            var layoutSetting = settingsProvider.GetSettings<ShellLayoutSettings>();
             var currentLayoutVersion = GetCurrentLayoutVersion();
 
             if (layoutSetting.LayoutVersion == currentLayoutVersion)

--- a/src/ServiceInsight/Shell/Shell.xaml.cs
+++ b/src/ServiceInsight/Shell/Shell.xaml.cs
@@ -56,7 +56,7 @@
 
         public void OnSaveLayout(ISettingsProvider settingProvider)
         {
-            var layoutSetting = settingProvider.GetSettings<ShellLayoutSettings>();
+            var layoutSetting = settingProvider.GetSettings<ShellLayoutSettings>() ?? new ShellLayoutSettings();
 
             if (!layoutSetting.ResetLayout)
             {


### PR DESCRIPTION
I can't replicate the cause of this, but once the settings have saved `null` as the value, the restore layout breaks exactly as the issue describes.

This fixes the issue when a null layout is saved.

See #566