### PR TITLE
Introduced rx sc component and adapted endpoint explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,41 +1,4 @@
-nugets
-chocos/
-deploy
-build32
-binaries
-*.vshost.*
-.nu
-_UpgradeReport.*
-*.cache
-*~
-*.swp
-results
-CommonAssemblyInfo.cs
-lib/sqlite/System.Data.SQLite.dll
-*.orig
-Samples/DataBus/storage
-packages
-PrecompiledWeb
-core-only
-Release
-Artifacts
-LogFiles
-csx
-*.ncrunchproject
-*.ncrunchsolution
-_NCrunch_NServiceBus/*
-logs
-run-git.cmd
-src/Chocolatey/Build/*
-
-installer/[F|f]iles
-installer/[C|c]ustom[A|a]ctions
-installer/ServiceControl-cache
-
-Index.dat
-Storage.dat
-
-# Created by https://www.gitignore.io
+# Created by https://www.gitignore.io/api/visualstudio
 
 ### VisualStudio ###
 ## Ignore Visual Studio temporary files, build results, and
@@ -47,6 +10,9 @@ Storage.dat
 *.userosscache
 *.sln.docstates
 
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
@@ -54,30 +20,240 @@ Storage.dat
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/
+[Ll]og/
 
-# Roslyn cache directories
-*.ide/
+# Visual Studio 2015 cache/options directory
+.vs/
+# Uncomment if you have tasks that create the project's static files in wwwroot
+#wwwroot/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*
 
-#NUNIT
+# NUNIT
 *.VisualState.xml
 TestResult.xml
 
-# NCrunch
-_NCrunch_*
-.*crunch*.local.xml
+# Build Results of an ATL Project
+[Dd]ebugPS/
+[Rr]eleasePS/
+dlldata.c
+
+# DNX
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+*_i.c
+*_p.c
+*_i.h
+*.ilk
+*.meta
+*.obj
+*.pch
+*.pdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Chutzpah Test files
+_Chutzpah*
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+
+# Visual Studio profiler
+*.psess
+*.vsp
+*.vspx
+*.sap
+
+# TFS 2012 Local Workspace
+$tf/
+
+# Guidance Automation Toolkit
+*.gpState
 
 # ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
-src/scaffolding.config
-src/Setup/ServiceInsight-cache/
+# JustCode is a .NET coding add-in
+.JustCode
+
+# TeamCity is a build add-in
+_TeamCity*
+
+# DotCover is a Code Coverage Tool
+*.dotCover
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# MightyMoose
+*.mm.*
+AutoTest.Net/
+
+# Web workbench (sass)
+.sass-cache/
+
+# Installshield output folder
+[Ee]xpress/
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/*.HxT
+DocProject/Help/*.HxC
+DocProject/Help/*.hhc
+DocProject/Help/*.hhk
+DocProject/Help/*.hhp
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# TODO: Comment the next line if you want to checkin your web deploy settings
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/packages/repositories.config
+# NuGet v3's project.json files produces more ignoreable files
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.pfx
+*.publishsettings
+node_modules/
+orleans.codegen.cs
+
+# Since there are multiple workflows, uncomment next line to ignore bower_components
+# (https://github.com/github/gitignore/pull/1529#issuecomment-104372622)
+#bower_components/
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file
+# to a newer Visual Studio version. Backup files are not needed,
+# because we have git ;-)
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+
+# SQL Server files
+*.mdf
+*.ldf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings
+
+# Microsoft Fakes
+FakesAssemblies/
+
+# GhostDoc plugin setting file
+*.GhostDoc.xml
+
+# Node.js Tools for Visual Studio
+.ntvs_analysis.dat
+
+# Visual Studio 6 build log
+*.plg
+
+# Visual Studio 6 workspace options file
+*.opt
+
+# Visual Studio LightSwitch build output
+**/*.HTMLClient/GeneratedArtifacts
+**/*.DesktopClient/GeneratedArtifacts
+**/*.DesktopClient/ModelManifest.xml
+**/*.Server/GeneratedArtifacts
+**/*.Server/ModelManifest.xml
+_Pvt_Extensions
+
+# Paket dependency manager
+.paket/paket.exe
+paket-files/
+
+# FAKE - F# Make
+.fake/
+
+# JetBrains Rider
+.idea/
+*.sln.iml
+
+# CodeRush
+.cr/

--- a/src/ServiceInsight.Tests/ShellViewModelTests.cs
+++ b/src/ServiceInsight.Tests/ShellViewModelTests.cs
@@ -6,6 +6,7 @@
     using NSubstitute;
     using NUnit.Framework;
     using Particular.Licensing;
+    using ServiceControl;
     using ServiceInsight.Explorer.EndpointExplorer;
     using ServiceInsight.Framework.Events;
     using ServiceInsight.Framework.Licensing;
@@ -91,6 +92,8 @@
                         headerView,
                         sequenceDiagramView,
                         settingsProvider,
+                        Substitute.For<ServiceControlConnectionProvider>(),
+                        Substitute.For<IServiceControl>(),
                         messageProperties,
                         logWindow,
                         commandLineArgParser);

--- a/src/ServiceInsight.Tests/ShellViewModelTests.cs
+++ b/src/ServiceInsight.Tests/ShellViewModelTests.cs
@@ -8,6 +8,7 @@
     using Particular.Licensing;
     using ServiceControl;
     using ServiceInsight.Explorer.EndpointExplorer;
+    using ServiceInsight.Framework;
     using ServiceInsight.Framework.Events;
     using ServiceInsight.Framework.Licensing;
     using ServiceInsight.Framework.Settings;
@@ -94,6 +95,7 @@
                         settingsProvider,
                         Substitute.For<ServiceControlConnectionProvider>(),
                         Substitute.For<IServiceControl>(),
+                        Substitute.For<IRxServiceControl>(),
                         messageProperties,
                         logWindow,
                         commandLineArgParser);

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -22,14 +22,14 @@
         IEventAggregator eventAggregator;
         string initialEndpoint;
 
-        public EndpointExplorerViewModel(IEventAggregator eventAggregator, CommandLineArgParser commandLineParser)
+        public EndpointExplorerViewModel(IRxServiceControl serviceControl, IEventAggregator eventAggregator, CommandLineArgParser commandLineParser)
         {
             this.eventAggregator = eventAggregator;
             Items = new BindableCollection<ExplorerItem>();
 
             initialEndpoint = commandLineParser.ParsedOptions.EndpointName;
 
-            RxServiceControl.Instance.Endpoints().Subscribe(MergeEndpoints);
+            serviceControl.Endpoints().Subscribe(MergeEndpoints);
         }
 
         private void MergeEndpoints(ServiceControlData e)

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Linq;
     using Caliburn.Micro;
-    using EndpointExplorer;
     using Framework;
     using Framework.Events;
     using Newtonsoft.Json;
@@ -11,11 +10,11 @@
 
     public class EndpointExplorerViewModel : Screen, IHandle<RequestSelectingEndpoint>, IHandle<SelectedExplorerItemChanged>
     {
-        static JsonSerializer serializer = new JsonSerializer();
+        static JsonSerializer serializer;
 
         static EndpointExplorerViewModel()
         {
-            serializer.ContractResolver = new SnakeCasePropertyNamesContractResolver();
+            serializer = new JsonSerializer { ContractResolver = new SnakeCasePropertyNamesContractResolver() };
         }
 
         IEventAggregator eventAggregator;
@@ -42,9 +41,9 @@
 
             var toRemove = root.Children.ToList();
             var endpointInstancesGroupedByName = e.Data.OrderBy(x => x.name).GroupBy(x => x.name);
-            foreach (var scaledOutEndpoint in endpointInstancesGroupedByName)
+            foreach (var endpointGroup in endpointInstancesGroupedByName)
             {
-                var instances = scaledOutEndpoint.ToList();
+                var instances = endpointGroup.ToList();
                 var endpoint = instances.Cast<JObject>().First().ToObject<Models.Endpoint>(serializer);
                 var node = root.GetEndpointNode(endpoint);
                 if (node != null)

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -3,203 +3,97 @@
     using System;
     using System.Linq;
     using Caliburn.Micro;
-    using ServiceInsight.ExtensionMethods;
-    using ServiceInsight.Framework;
-    using ServiceInsight.Framework.Events;
-    using ServiceInsight.Framework.Settings;
-    using ServiceInsight.ServiceControl;
-    using ServiceInsight.Settings;
-    using ServiceInsight.Shell;
-    using ServiceInsight.Startup;
+    using EndpointExplorer;
+    using Framework;
+    using Framework.Events;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
-    public class EndpointExplorerViewModel : Screen,
-        IHandle<RequestSelectingEndpoint>
+    public class EndpointExplorerViewModel : Screen, IHandle<RequestSelectingEndpoint>, IHandle<SelectedExplorerItemChanged>
     {
-        IEventAggregator eventAggregator;
-        ISettingsProvider settingsProvider;
-        IServiceControl serviceControl;
-        NetworkOperations networkOperations;
-        ServiceControlConnectionProvider connectionProvider;
-        CommandLineArgParser commandLineParser;
+        static JsonSerializer serializer = new JsonSerializer();
 
-        public EndpointExplorerViewModel(
-            IEventAggregator eventAggregator,
-            ISettingsProvider settingsProvider,
-            ServiceControlConnectionProvider connectionProvider,
-            CommandLineArgParser commandLineParser,
-            IServiceControl serviceControl,
-            NetworkOperations networkOperations)
+        static EndpointExplorerViewModel()
+        {
+            serializer.ContractResolver = new SnakeCasePropertyNamesContractResolver();
+        }
+
+        IEventAggregator eventAggregator;
+
+        public EndpointExplorerViewModel(IEventAggregator eventAggregator)
         {
             this.eventAggregator = eventAggregator;
-            this.settingsProvider = settingsProvider;
-            this.serviceControl = serviceControl;
-            this.networkOperations = networkOperations;
-            this.connectionProvider = connectionProvider;
-            this.commandLineParser = commandLineParser;
             Items = new BindableCollection<ExplorerItem>();
+
+            RxServiceControl.Instance.Endpoints().Subscribe(MergeEndpoints);
+        }
+
+        private void MergeEndpoints(ServiceControlData e)
+        {
+            var root = Items.OfType<ServiceControlExplorerItem>().SingleOrDefault(i => i.Name == e.Url);
+
+            if (root == null)
+            {
+                root = new ServiceControlExplorerItem(e.Url);
+                root.IsExpanded = true;
+
+                Items.Add(root);
+            }
+
+            var toRemove = root.Children.ToList();
+            var endpointInstancesGroupedByName = e.Data.OrderBy(x => x.name).GroupBy(x => x.name);
+            foreach (var scaledOutEndpoint in endpointInstancesGroupedByName)
+            {
+                var instances = scaledOutEndpoint.ToList();
+                var endpoint = instances.Cast<JObject>().First().ToObject<Models.Endpoint>(serializer);
+                var node = root.GetEndpointNode(endpoint);
+                if (node != null)
+                {
+                    toRemove.Remove(node);
+                    continue;
+                }
+
+                var hostNames = instances.Select(instance => instance.host_display_name).Distinct();
+                var tooltip = string.Join(", ", hostNames);
+
+                root.Children.Add(new AuditEndpointExplorerItem(endpoint, tooltip));
+            }
+            if (toRemove.Any())
+            {
+                var saveSelectedNode = SelectedNode;
+                root.Children.RemoveRange(toRemove);
+                SelectedNode = saveSelectedNode;
+            }
         }
 
         public IObservableCollection<ExplorerItem> Items { get; }
 
-        public ServiceControlExplorerItem ServiceControlRoot => Items.OfType<ServiceControlExplorerItem>().FirstOrDefault();
-
         public ExplorerItem SelectedNode { get; set; }
-
-        public string ServiceUrl { get; private set; }
-
-        public new ShellViewModel Parent => (ShellViewModel)base.Parent;
-
-        bool IsConnected => ServiceUrl != null;
-
-        protected override void OnActivate()
-        {
-            base.OnActivate();
-
-            if (IsConnected)
-            {
-                return;
-            }
-
-            var configuredConnection = GetConfiguredAddress();
-            var existingConnection = connectionProvider.Url;
-            var available = ServiceAvailable(configuredConnection);
-            var connectTo = available ? configuredConnection : existingConnection;
-
-            eventAggregator.PublishOnUIThread(new WorkStarted("Trying to connect to ServiceControl at {0}", connectTo));
-
-            ConnectToService(connectTo);
-
-            SelectDefaultEndpoint();
-
-            eventAggregator.PublishOnUIThread(new WorkFinished());
-        }
-
-        string GetConfiguredAddress()
-        {
-            if (commandLineParser.ParsedOptions.EndpointUri == null)
-            {
-                var appSettings = settingsProvider.GetSettings<ProfilerSettings>();
-                if (appSettings != null && appSettings.LastUsedServiceControl != null)
-                {
-                    return appSettings.LastUsedServiceControl;
-                }
-
-                var managementConfig = settingsProvider.GetSettings<ServiceControlSettings>();
-                return string.Format("http://localhost:{0}/api", managementConfig.Port);
-            }
-
-            return commandLineParser.ParsedOptions.EndpointUri.ToString();
-        }
-
-        bool ServiceAvailable(string serviceUrl)
-        {
-            connectionProvider.ConnectTo(serviceUrl);
-
-            var connected = serviceControl.IsAlive();
-
-            return connected;
-        }
-
-        void AddServiceNode()
-        {
-            Items.Clear();
-            Items.Add(new ServiceControlExplorerItem(ServiceUrl));
-        }
 
         public void OnSelectedNodeChanged()
         {
             eventAggregator.PublishOnUIThread(new SelectedExplorerItemChanged(SelectedNode));
         }
 
-        void SelectDefaultEndpoint()
-        {
-            if (ServiceControlRoot == null)
-            {
-                return;
-            }
-
-            if (!commandLineParser.ParsedOptions.EndpointName.IsEmpty())
-            {
-                foreach (var endpoint in ServiceControlRoot.Children)
-                {
-                    if (endpoint.Name.Equals(commandLineParser.ParsedOptions.EndpointName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        //SelectedNode = endpoint;
-                        SelectedNode = ServiceControlRoot;
-                        break;
-                    }
-                }
-            }
-            else
-            {
-                SelectedNode = ServiceControlRoot;
-            }
-        }
-
-        public void ConnectToService(string url)
-        {
-            if (url == null)
-            {
-                return;
-            }
-
-            connectionProvider.ConnectTo(url);
-            ServiceUrl = url;
-            AddServiceNode();
-            RefreshData();
-            ExpandServiceNode();
-        }
-
-        public void RefreshData()
-        {
-            if (ServiceControlRoot == null)
-            {
-                TryReconnectToServiceControl();
-            }
-            if (ServiceControlRoot == null)
-            {
-                return;
-            }
-
-            var endpoints = serviceControl.GetEndpoints();
-            if (endpoints == null)
-            {
-                return;
-            }
-
-            ServiceControlRoot.Children.Clear();
-
-            var endpointInstancesGroupedByName = endpoints.OrderBy(x => x.Name).GroupBy(x => x.Name);
-            foreach (var scaledOutEndpoint in endpointInstancesGroupedByName)
-            {
-                var instances = scaledOutEndpoint.ToList();
-                var hostNames = instances.Select(instance => instance.HostDisplayName).Distinct();
-                var tooltip = string.Join(", ", hostNames);
-                ServiceControlRoot.Children.Add(new AuditEndpointExplorerItem(instances.First(), tooltip));
-            }
-        }
-
-        void TryReconnectToServiceControl()
-        {
-            ConnectToService(GetConfiguredAddress());
-        }
-
-        public void Navigate(string navigateUri)
-        {
-            networkOperations.Browse(navigateUri);
-        }
-
-        void ExpandServiceNode()
-        {
-            ServiceControlRoot.IsExpanded = true;
-        }
-
         public void Handle(RequestSelectingEndpoint message)
         {
-            if (ServiceControlRoot.EndpointExists(message.Endpoint))
+            foreach (var item in Items.OfType<ServiceControlExplorerItem>())
             {
-                var node = ServiceControlRoot.GetEndpointNode(message.Endpoint);
-                SelectedNode = node;
+                if (item.EndpointExists(message.Endpoint))
+                {
+                    var node = item.GetEndpointNode(message.Endpoint);
+                    SelectedNode = node;
+                    break;
+                }
+            }
+        }
+
+        public void Handle(SelectedExplorerItemChanged message)
+        {
+            var endpoint = message.SelectedExplorerItem as AuditEndpointExplorerItem;
+            if (endpoint != null)
+            {
+                Handle(new RequestSelectingEndpoint(endpoint.Endpoint));
             }
         }
     }

--- a/src/ServiceInsight/Explorer/EndpointExplorer/ServiceControlExplorerItem.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/ServiceControlExplorerItem.cs
@@ -14,8 +14,8 @@
 
         public override Bitmap Image => Resources.TreeMonitoring;
 
-        public bool EndpointExists(Endpoint endpoint) => Children.Any(item => item.Endpoint == endpoint);
+        public bool EndpointExists(Endpoint endpoint) => Children.Any(item => object.Equals(item.Endpoint, endpoint));
 
-        public EndpointExplorerItem GetEndpointNode(Endpoint endpoint) => Children.First(item => item.Endpoint == endpoint);
+        public EndpointExplorerItem GetEndpointNode(Endpoint endpoint) => Children.FirstOrDefault(item => object.Equals(item.Endpoint, endpoint));
     }
 }

--- a/src/ServiceInsight/ExtensionMethods/AkavacheExtensions.cs
+++ b/src/ServiceInsight/ExtensionMethods/AkavacheExtensions.cs
@@ -1,0 +1,108 @@
+﻿namespace ServiceInsight.ExtensionMethods
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Reactive.Linq;
+    using Akavache;
+
+    public static class AkavacheExtensions
+    {
+        public static IObservable<string> GetOrFetchWithETag(this IBlobCache cache, string url)
+        {
+            var result =
+                // Get from cache
+                cache.GetObject<string>(url)
+
+                // Cached values are true
+                .Select(x => Tuple.Create(x, true))
+
+                // Turn exceptions into false
+                .Catch(Observable.Return(Tuple.Create(string.Empty, false)))
+
+                // If true, return an observable with the result, else an empty observable.
+                .SelectMany(x => x.Item2 ? Observable.Return(x.Item1) : Observable.Empty<string>());
+
+            var fetch =
+                // Get the ETag from cache
+                cache.GetObject<string>("etag-" + url)
+
+                // Exceptions => Blank ETag
+                .Catch(Observable.Return(string.Empty))
+
+                // Call our web method
+                .SelectMany(etag => GetFromWeb(url, etag)
+
+                    // Invalidate the old and add the new etag to the cache
+                    .SelectMany(x => cache.InvalidateObject<string>("etag-" + url).Select(_ => x))
+                    .SelectMany(x => cache.InsertObject("etag-" + url, x.Item1).Select(_ => x))
+
+                    // Invalidate the old and add the new data to the cache
+                    .SelectMany(x => cache.InvalidateObject<string>(url).Select(_ => x))
+                    .SelectMany(x => cache.InsertObject(url, x.Item2).Select(_ => x)))
+
+                // Select the data from the tuple
+                .Select(x => x.Item2);
+
+            return result
+                .Concat(fetch)
+                .Replay()
+                .RefCount();
+        }
+
+        private static HttpClient CreateWebClient()
+        {
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression)
+            {
+                handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            }
+
+            var client = new HttpClient(handler);
+            return client;
+        }
+
+        private static IObservable<Tuple<string, string>> GetFromWeb(string url, string etag)
+        {
+            return Observable.Create<Tuple<string, string>>(async observer =>
+            {
+                using (var client = CreateWebClient())
+                {
+                    var request = new HttpRequestMessage
+                    {
+                        Method = HttpMethod.Get,
+                        RequestUri = new Uri(url)
+                    };
+
+                    if (!string.IsNullOrEmpty(etag))
+                    {
+                        request.Headers.TryAddWithoutValidation("If-None-Match", etag);
+                    }
+
+                    var response = await client.SendAsync(request)
+                        .ConfigureAwait(false);
+
+                    if (!response.IsSuccessStatusCode &&
+                        response.StatusCode != HttpStatusCode.NotModified)
+                    {
+                        observer.OnError(new HttpRequestException(
+                            "Status code: " + response.StatusCode));
+                    }
+                    else if (response.IsSuccessStatusCode)
+                    {
+                        var data = await response.Content.ReadAsStringAsync()
+                            .ConfigureAwait(false);
+
+                        //observer.OnNext(Tuple.Create(response.Headers.ETag.Tag, data));
+
+                        // Because SC doesn't send etags properly
+                        var resultEtag = response.Headers.First(h => h.Key == "ETag").Value.First();
+                        observer.OnNext(Tuple.Create(resultEtag, data));
+                    }
+                }
+                observer.OnCompleted();
+            });
+        }
+    }
+}

--- a/src/ServiceInsight/ExtensionMethods/StringExtensions.cs
+++ b/src/ServiceInsight/ExtensionMethods/StringExtensions.cs
@@ -1,19 +1,7 @@
 ﻿namespace ServiceInsight.ExtensionMethods
 {
-    using System;
-
     public static class StringExtensions
     {
-        public static bool IsEmpty(this string value) => string.IsNullOrEmpty(value) || string.IsNullOrWhiteSpace(value);
-
-        public static bool Contains(this string source, string toCheck, StringComparison comparison)
-        {
-            if (IsEmpty(source))
-            {
-                return true;
-            }
-
-            return source.IndexOf(toCheck, comparison) >= 0;
-        }
+        public static bool IsEmpty(this string value) => string.IsNullOrWhiteSpace(value);
     }
 }

--- a/src/ServiceInsight/ExtensionMethods/ViewModelExtensions.cs
+++ b/src/ServiceInsight/ExtensionMethods/ViewModelExtensions.cs
@@ -2,14 +2,15 @@
 {
     using System;
     using System.Linq.Expressions;
+    using System.Reactive;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using ReactiveUI;
 
     public static class ViewModelExtensions
     {
-        // ReSharper disable UnusedParameter.Global
         public static ICommand CreateCommand<TViewModel>(this TViewModel viewModel, Action executAction, IObservable<bool> canExecuteObservable) where TViewModel : class
-        // ReSharper restore UnusedParameter.Global
         {
             var command = new ReactiveCommand(canExecuteObservable);
             command.Subscribe(_ => executAction());
@@ -23,21 +24,28 @@
             return command;
         }
 
-        // ReSharper disable UnusedParameter.Global
         public static ICommand CreateCommand<TViewModel>(this TViewModel viewModel, Action executAction) where TViewModel : class
-        // ReSharper restore UnusedParameter.Global
         {
             var command = new ReactiveCommand();
             command.Subscribe(_ => executAction());
             return command;
         }
 
-        // ReSharper disable UnusedParameter.Global
         public static ICommand CreateCommand<TViewModel>(this TViewModel viewModel, Action<object> executAction) where TViewModel : class
-        // ReSharper restore UnusedParameter.Global
         {
             var command = new ReactiveCommand();
             command.Subscribe(arg => executAction(arg));
+            return command;
+        }
+
+        public static ICommand CreateCommandAsync<TViewModel>(this TViewModel viewModel, Func<Task> executAction) where TViewModel : class
+        {
+            var command = new ReactiveCommand();
+            command.SelectMany(async _ =>
+            {
+                await executAction();
+                return Unit.Default;
+            }).Subscribe();
             return command;
         }
     }

--- a/src/ServiceInsight/Framework/AsyncPump.cs
+++ b/src/ServiceInsight/Framework/AsyncPump.cs
@@ -1,0 +1,42 @@
+﻿namespace ServiceInsight.Framework
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Windows.Threading;
+
+    public static class AsyncPump
+    {
+        public static void Run(Func<Task> func)
+        {
+            if (func == null)
+            {
+                throw new ArgumentNullException(nameof(func));
+            }
+
+            var prevCtx = SynchronizationContext.Current;
+            try
+            {
+                var syncCtx = new DispatcherSynchronizationContext();
+                SynchronizationContext.SetSynchronizationContext(syncCtx);
+
+                var t = func();
+                if (t == null)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                var frame = new DispatcherFrame();
+                t.ContinueWith(_ => { frame.Continue = false; },
+                    TaskScheduler.Default);
+                Dispatcher.PushFrame(frame);
+
+                t.GetAwaiter().GetResult();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevCtx);
+            }
+        }
+    }
+}

--- a/src/ServiceInsight/Framework/Behaviors/BindableSelectedItemBehavior.cs
+++ b/src/ServiceInsight/Framework/Behaviors/BindableSelectedItemBehavior.cs
@@ -14,15 +14,73 @@
 
         public static readonly DependencyProperty SelectedItemProperty =
             DependencyProperty.Register("SelectedItem", typeof(object), typeof(BindableSelectedItemBehavior),
-            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedItemChanged));
+            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, StaticOnSelectedItemChanged));
 
-        private static void OnSelectedItemChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+        private static void StaticOnSelectedItemChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
         {
-            var item = e.NewValue as TreeViewItem;
+            var behavior = sender as BindableSelectedItemBehavior;
+            if (behavior != null)
+            {
+                behavior.OnSelectedItemChanged(e);
+            }
+        }
+
+        private void OnSelectedItemChanged(DependencyPropertyChangedEventArgs e)
+        {
+            if (AssociatedObject == null)
+            {
+                return;
+            }
+
+            var thisItem = AssociatedObject.ItemContainerGenerator.ContainerFromItem(e.NewValue) as TreeViewItem;
+            if (thisItem != null)
+            {
+                thisItem.IsSelected = true;
+                return;
+            }
+
+            for (int i = 0; i < AssociatedObject.Items.Count; i++)
+            {
+                SelectItem(e.NewValue, AssociatedObject.ItemContainerGenerator.ContainerFromIndex(i) as TreeViewItem);
+            }
+        }
+
+        private static bool SelectItem(object o, TreeViewItem parentItem)
+        {
+            if (parentItem == null)
+            {
+                return false;
+            }
+
+            if (!parentItem.IsExpanded)
+            {
+                parentItem.IsExpanded = true;
+                parentItem.UpdateLayout();
+            }
+
+            var item = parentItem.ItemContainerGenerator.ContainerFromItem(o) as TreeViewItem;
             if (item != null)
             {
-                item.SetValue(TreeViewItem.IsSelectedProperty, true);
+                item.IsSelected = true;
+                return true;
             }
+
+            var wasFound = false;
+            for (int i = 0; i < parentItem.Items.Count; i++)
+            {
+                TreeViewItem itm = parentItem.ItemContainerGenerator.ContainerFromIndex(i) as TreeViewItem;
+                var found = SelectItem(o, itm);
+                if (!found)
+                {
+                    itm.IsExpanded = false;
+                }
+                else
+                {
+                    wasFound = true;
+                }
+            }
+
+            return wasFound;
         }
 
         protected override void OnAttached()

--- a/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
+++ b/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
@@ -29,7 +29,7 @@
                 .WriteTo.Trace(outputTemplate: "[{Level}] ({SourceContext}) {Message}{NewLine}{Exception}")
                 .WriteTo.Logger(lc => lc
                     .MinimumLevel.Verbose()
-                    .Filter.ByIncludingOnly(Matching.FromSource<IServiceControl>())
+                    .Filter.ByIncludingOnly(le => Matching.FromSource<IServiceControl>()(le) || Matching.FromSource<IRxServiceControl>()(le))
                     .WriteTo.Observers(logEvents => logEvents.Do(LogWindowViewModel.LogObserver).ObserveOnDispatcher().Subscribe()))
                 .CreateLogger();
         }

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Xml;
+    using Akavache;
     using Autofac;
     using Models;
     using ServiceControl;
@@ -20,6 +21,7 @@
             builder.RegisterType<AppLicenseManager>().SingleInstance();
             builder.RegisterType<ServiceControlConnectionProvider>().InstancePerLifetimeScope();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
+            builder.RegisterInstance(new RxServiceControl(BlobCache.UserAccount)).As<IRxServiceControl>().SingleInstance();
             builder.RegisterType<CommandLineArgParser>().SingleInstance().OnActivating(e => e.Instance.Parse());
         }
     }

--- a/src/ServiceInsight/Framework/RxServiceControl.cs
+++ b/src/ServiceInsight/Framework/RxServiceControl.cs
@@ -1,0 +1,181 @@
+﻿namespace ServiceInsight.Framework
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Reactive;
+    using System.Reactive.Linq;
+    using System.Reactive.Subjects;
+    using System.Threading.Tasks;
+    using Akavache;
+    using Anotar.Serilog;
+    using ExtensionMethods;
+    using Newtonsoft.Json.Linq;
+    using ReactiveUI;
+    using Serilog;
+
+    interface IRxServiceControl
+    {
+        Task Refresh();
+
+        Task<bool> AddServiceControl(string url);
+
+        Task<bool> RemoveServiceControl(string url);
+
+        Task ClearServiceControls();
+
+        IObservable<ServiceControlData> Endpoints();
+
+        IObservable<ServiceControlData> Messages();
+
+        IObservable<ServiceControlData> EndpointMessages(string endpointName);
+
+        void SetRefresh(TimeSpan interval);
+
+        void DisableRefresh();
+    }
+
+    class RxServiceControl : IRxServiceControl
+    {
+        static Serilog.ILogger anotarLogger = Log.ForContext<IRxServiceControl>();
+
+        public static IRxServiceControl Instance { get; set; }
+
+        readonly IBlobCache cache;
+
+        List<string> serviceControlUrls;
+
+        Subject<Unit> manualRefresh;
+        Subject<IObservable<Unit>> trigger;
+        IObservable<Unit> subject;
+
+        public RxServiceControl(IBlobCache cache)
+        {
+            this.cache = cache;
+
+            serviceControlUrls = new List<string>();
+
+            manualRefresh = new Subject<Unit>();
+            trigger = new Subject<IObservable<Unit>>();
+
+            subject = Observable.Merge(
+                manualRefresh,
+                trigger.Switch());
+        }
+
+        public Task Refresh()
+        {
+            manualRefresh.OnNext(Unit.Default);
+            return Task.FromResult(0);
+        }
+
+        public async Task<bool> AddServiceControl(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException($"{nameof(url)} is null or empty.", nameof(url));
+            }
+
+            url = url.TrimEnd('/');
+            using (var client = new HttpClient())
+            {
+                try
+                {
+                    var page = (await client.GetStringAsync(url)).Trim();
+                    JObject.Parse(page);
+                    serviceControlUrls.Add(url);
+                    return true;
+                }
+                catch
+                {
+                    // TODO need to log invalid url
+                    return false;
+                }
+            }
+        }
+
+        public Task<bool> RemoveServiceControl(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new ArgumentException($"{nameof(url)} is null or empty.", nameof(url));
+            }
+
+            return Task.FromResult(serviceControlUrls.Remove(url.TrimEnd('/')));
+        }
+
+        public Task ClearServiceControls()
+        {
+            serviceControlUrls.Clear();
+            return Task.FromResult(0);
+        }
+
+        public IObservable<ServiceControlData> Endpoints()
+        {
+            return subject.SelectMany(_ =>
+            {
+                var data = serviceControlUrls.Select(url =>
+                    GetData($"{url}/endpoints")
+                    .Select(d => new ServiceControlData(url, d)));
+
+                return Observable.Merge(data);
+            }).Publish().RefCount();
+        }
+
+        public IObservable<ServiceControlData> Messages()
+        {
+            return subject.SelectMany(_ =>
+            {
+                var data = serviceControlUrls.Select(url =>
+                    GetData($"{url}/messages")
+                    .Select(d => new ServiceControlData(url, d)));
+
+                return Observable.Merge(data);
+            }).Publish().RefCount();
+        }
+
+        public IObservable<ServiceControlData> EndpointMessages(string endpointName)
+        {
+            return subject.SelectMany(_ =>
+            {
+                var data = serviceControlUrls.Select(url =>
+                    GetData($"{url}/endpoints/{endpointName}/messages/")
+                    .Select(d => new ServiceControlData(url, d)));
+
+                return Observable.Merge(data);
+            }).Publish().RefCount();
+        }
+
+        private IObservable<IEnumerable<JObject>> GetData(string url)
+        {
+            LogTo.Information("Rx HTTP {url}", url);
+
+            return cache.GetOrFetchWithETag(url)
+                .Select(j => JArray.Parse(j).Cast<JObject>());
+        }
+
+        public void SetRefresh(TimeSpan interval)
+        {
+            trigger.OnNext(Observable.Interval(interval).Select(_ => Unit.Default).ObserveOn(RxApp.MainThreadScheduler));
+        }
+
+        public void DisableRefresh()
+        {
+            trigger.OnNext(Observable.Never<Unit>());
+        }
+    }
+
+    class ServiceControlData
+    {
+        public ServiceControlData(string url, IEnumerable<JObject> data)
+        {
+            Data = data;
+            Url = url;
+        }
+
+        public string Url { get; }
+
+        public IEnumerable<dynamic> Data { get; }
+    }
+}

--- a/src/ServiceInsight/Framework/SnakeCasePropertyNamesContractResolver.cs
+++ b/src/ServiceInsight/Framework/SnakeCasePropertyNamesContractResolver.cs
@@ -1,0 +1,46 @@
+﻿namespace ServiceInsight.Framework
+{
+    using System.Collections.Generic;
+    using System.Text;
+    using Newtonsoft.Json.Serialization;
+
+    public class SnakeCasePropertyNamesContractResolver : DeliminatorSeparatedPropertyNamesContractResolver
+    {
+        public SnakeCasePropertyNamesContractResolver()
+            : base('_') { }
+    }
+
+    public class DeliminatorSeparatedPropertyNamesContractResolver : DefaultContractResolver
+    {
+        private readonly string separator;
+
+        protected DeliminatorSeparatedPropertyNamesContractResolver(char separator)
+            : base(true)
+        {
+            this.separator = separator.ToString();
+        }
+
+        protected override string ResolvePropertyName(string propertyName)
+        {
+            var parts = new List<string>();
+            var currentWord = new StringBuilder();
+
+            foreach (var c in propertyName)
+            {
+                if (char.IsUpper(c) && currentWord.Length > 0)
+                {
+                    parts.Add(currentWord.ToString());
+                    currentWord.Clear();
+                }
+                currentWord.Append(char.ToLower(c));
+            }
+
+            if (currentWord.Length > 0)
+            {
+                parts.Add(currentWord.ToString());
+            }
+
+            return string.Join(separator, parts.ToArray());
+        }
+    }
+}

--- a/src/ServiceInsight/GlobalSuppressions.cs
+++ b/src/ServiceInsight/GlobalSuppressions.cs
@@ -8,3 +8,4 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1516:Elements must be separated by blank line", Justification = "Generated File", Scope = "member", Target = "~P:ReleaseDateAttribute.Date")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1517:CodeMustNotContainBlankLinesAtStartOfFile", Justification = "Generated File. Bring back when updated to GitVersionTask v3.x")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1518:CodeMustNotContainBlankLinesAtEndOfFile", Justification = "Generated File. Bring back when updated to GitVersionTask v3.x")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PCR0001:Await used without specifying ConfigureAwait", Justification = "Default in WPF is fine.")]

--- a/src/ServiceInsight/LogWindow/LogWindowView.xaml.cs
+++ b/src/ServiceInsight/LogWindow/LogWindowView.xaml.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Reactive.Linq;
     using System.Windows;
-    using ReactiveUI;
 
     public partial class LogWindowView
     {
@@ -29,7 +28,7 @@
                 logSubscription.Dispose();
             }
 
-            logSubscription = vm.Logs.ItemsAdded.SubscribeOn(RxApp.MainThreadScheduler).Subscribe(_ => richTextBox.ScrollToEnd());
+            logSubscription = vm.Logs.ItemsAdded.Subscribe(_ => richTextBox.ScrollToEnd());
         }
     }
 }

--- a/src/ServiceInsight/LogWindow/LoggingRichTextBoxBehavior.cs
+++ b/src/ServiceInsight/LogWindow/LoggingRichTextBoxBehavior.cs
@@ -73,7 +73,6 @@ namespace ServiceInsight.LogWindow
 
             logSubscription = logs.Changed
                 .Where(e => e.Action == NotifyCollectionChangedAction.Add || e.Action == NotifyCollectionChangedAction.Reset)
-                .SubscribeOn(RxApp.MainThreadScheduler)
                 .Subscribe(ProcessChange);
         }
 

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -128,14 +128,6 @@
             return messages;
         }
 
-        public IEnumerable<Endpoint> GetEndpoints()
-        {
-            var request = new RestRequestWithCache(EndpointsEndpoint, RestRequestWithCache.CacheStyle.IfNotModified);
-            var messages = GetModel<List<Endpoint>>(request);
-
-            return messages ?? new List<Endpoint>();
-        }
-
         public IEnumerable<KeyValuePair<string, string>> GetMessageData(SagaMessage message)
         {
             var request = new RestRequestWithCache(string.Format(MessageBodyEndpoint, message.MessageId), message.Status == MessageStatus.Successful ? RestRequestWithCache.CacheStyle.Immutable : RestRequestWithCache.CacheStyle.IfNotModified);

--- a/src/ServiceInsight/ServiceControl/IServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/IServiceControl.cs
@@ -23,8 +23,6 @@ namespace ServiceInsight.ServiceControl
 
         IEnumerable<StoredMessage> GetConversationById(string conversationId);
 
-        IEnumerable<Endpoint> GetEndpoints();
-
         IEnumerable<KeyValuePair<string, string>> GetMessageData(SagaMessage messageId);
 
         void LoadBody(StoredMessage message);

--- a/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
@@ -1,10 +1,21 @@
 ﻿namespace ServiceInsight.ServiceControl
 {
+    using ServiceInsight.Framework;
+
     public class ServiceControlConnectionProvider
     {
         public void ConnectTo(string url)
         {
             Url = url;
+
+            AsyncPump.Run(async () =>
+            {
+                await RxServiceControl.Instance.ClearServiceControls();
+                await RxServiceControl.Instance.AddServiceControl(url);
+
+                // Prime the streams
+                await RxServiceControl.Instance.Refresh();
+            });
         }
 
         public string Url { get; private set; }

--- a/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
@@ -4,17 +4,24 @@
 
     public class ServiceControlConnectionProvider
     {
+        IRxServiceControl serviceControl;
+
+        public ServiceControlConnectionProvider(IRxServiceControl serviceControl)
+        {
+            this.serviceControl = serviceControl;
+        }
+
         public void ConnectTo(string url)
         {
             Url = url;
 
             AsyncPump.Run(async () =>
             {
-                await RxServiceControl.Instance.ClearServiceControls();
-                await RxServiceControl.Instance.AddServiceControl(url);
+                await serviceControl.ClearServiceControls();
+                await serviceControl.AddServiceControl(url);
 
                 // Prime the streams
-                await RxServiceControl.Instance.Refresh();
+                await serviceControl.Refresh();
             });
         }
 

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -55,6 +55,14 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="FodyWeavers.xml" />
+    <Reference Include="Akavache, Version=4.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\akavache.core.4.1.2\lib\net45\Akavache.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Akavache.Sqlite3, Version=4.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\akavache.sqlite3.4.1.2\lib\Portable-Net45+Win8+WP8+Wpa81\Akavache.Sqlite3.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Anotar.Serilog">
       <HintPath>..\packages\Anotar.Serilog.Fody.2.16.0.1\Lib\Anotar.Serilog.dll</HintPath>
       <Private>False</Private>
@@ -193,6 +201,14 @@
     <Reference Include="Serilog.FullNetFx">
       <HintPath>..\packages\Serilog.1.4.204\lib\net45\Serilog.FullNetFx.dll</HintPath>
     </Reference>
+    <Reference Include="Splat, Version=1.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Splat.1.6.2\lib\Net45\Splat.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SQLitePCL.raw, Version=0.8.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SQLitePCL.raw_basic.0.8.6\lib\net45\SQLitePCL.raw.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
@@ -202,6 +218,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Messaging" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Reactive.Core">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
@@ -256,8 +273,10 @@
       <DependentUpon>DiagramLegendView.xaml</DependentUpon>
     </Compile>
     <Compile Include="DiagramLegend\DiagramLegendViewModel.cs" />
+    <Compile Include="ExtensionMethods\AkavacheExtensions.cs" />
     <Compile Include="ExtensionMethods\JObjectExtensions.cs" />
     <Compile Include="Framework\Behaviors\CommandParameterHelper.cs" />
+    <Compile Include="Framework\AsyncPump.cs" />
     <Compile Include="Framework\Commands\BaseCommand.cs" />
     <Compile Include="Framework\Commands\ChangeSelectedMessageCommand.cs" />
     <Compile Include="Framework\Commands\CommandsModule.cs" />
@@ -273,6 +292,8 @@
     <Compile Include="Framework\RaygunUtility.cs" />
     <Compile Include="Framework\Rx\RxConductor.cs" />
     <Compile Include="Framework\Rx\RxScreen.cs" />
+    <Compile Include="Framework\RxServiceControl.cs" />
+    <Compile Include="Framework\SnakeCasePropertyNamesContractResolver.cs" />
     <Compile Include="Framework\UI\ScreenManager\IWindowManagerEx.cs" />
     <Compile Include="Framework\UI\ScreenManager\WindowManagerEx.cs">
       <SubType>Code</SubType>
@@ -514,7 +535,6 @@
     <Compile Include="Shell\StatusBarManager.cs" />
     <Compile Include="ExtensionMethods\BuilderExtensions.cs" />
     <Compile Include="Startup\CommandLineArgParser.cs" />
-    <Compile Include="Startup\ConfigurationSettingsReader.cs" />
     <Compile Include="Startup\EnvironmentWrapper.cs" />
     <Compile Include="Framework\Logging\LoggingConfig.cs" />
     <Compile Include="Startup\AppBootstrapper.cs" />
@@ -832,8 +852,10 @@
     <Error Condition="!Exists('..\packages\PropertyChanged.Fody.1.50.3\build\dotnet\PropertyChanged.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PropertyChanged.Fody.1.50.3\build\dotnet\PropertyChanged.Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.2.0.1\build\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.2.0.1\build\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\SQLitePCL.raw_basic.0.8.6\build\net45\SQLitePCL.raw_basic.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCL.raw_basic.0.8.6\build\net45\SQLitePCL.raw_basic.targets'))" />
   </Target>
   <Import Project="..\packages\Fody.1.29.3\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\PropertyChanged.Fody.1.50.3\build\dotnet\PropertyChanged.Fody.targets" Condition="Exists('..\packages\PropertyChanged.Fody.1.50.3\build\dotnet\PropertyChanged.Fody.targets')" />
   <Import Project="..\packages\GitVersionTask.2.0.1\build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.2.0.1\build\GitVersionTask.targets')" />
+  <Import Project="..\packages\SQLitePCL.raw_basic.0.8.6\build\net45\SQLitePCL.raw_basic.targets" Condition="Exists('..\packages\SQLitePCL.raw_basic.0.8.6\build\net45\SQLitePCL.raw_basic.targets')" />
 </Project>

--- a/src/ServiceInsight/Shell/ShellViewModel.cs
+++ b/src/ServiceInsight/Shell/ShellViewModel.cs
@@ -55,6 +55,7 @@
         Func<LicenseRegistrationViewModel> licenceRegistration;
         ServiceControlConnectionProvider connectionProvider;
         IServiceControl serviceControl;
+        IRxServiceControl rxServiceControl;
 
         public ShellViewModel(
             IAppCommands appCommander,
@@ -74,6 +75,7 @@
             ISettingsProvider settingsProvider,
             ServiceControlConnectionProvider connectionProvider,
             IServiceControl serviceControl,
+            IRxServiceControl rxServiceControl,
             MessagePropertiesViewModel messageProperties,
             LogWindowViewModel logWindow,
             CommandLineArgParser comandLineArgParser)
@@ -88,6 +90,7 @@
             this.licenceRegistration = licenceRegistration;
             this.connectionProvider = connectionProvider;
             this.serviceControl = serviceControl;
+            this.rxServiceControl = rxServiceControl;
             MessageProperties = messageProperties;
             MessageFlow = messageFlow;
             SagaWindow = sagaWindow;
@@ -256,7 +259,7 @@
         {
             if (manual)
             {
-                await RxServiceControl.Instance.Refresh();
+                await rxServiceControl.Refresh();
             }
             Messages.RefreshMessages();
             SagaWindow.RefreshSaga();
@@ -268,11 +271,11 @@
 
             if (AutoRefresh)
             {
-                RxServiceControl.Instance.SetRefresh(refreshTimer.Interval);
+                rxServiceControl.SetRefresh(refreshTimer.Interval);
             }
             else
             {
-                RxServiceControl.Instance.DisableRefresh();
+                rxServiceControl.DisableRefresh();
             }
         }
 

--- a/src/ServiceInsight/Startup/AppBootstrapper.cs
+++ b/src/ServiceInsight/Startup/AppBootstrapper.cs
@@ -30,8 +30,6 @@
         {
             BlobCache.ApplicationName = "ServiceInsight";
 
-            RxServiceControl.Instance = new RxServiceControl(BlobCache.UserAccount);
-
             CreateContainer();
             ExtendConventions();
             ApplyBindingCulture();

--- a/src/ServiceInsight/Startup/AppBootstrapper.cs
+++ b/src/ServiceInsight/Startup/AppBootstrapper.cs
@@ -6,6 +6,7 @@
     using System.Globalization;
     using System.Windows;
     using System.Windows.Markup;
+    using Akavache;
     using Autofac;
     using Caliburn.Micro;
     using DevExpress.Xpf.Bars;
@@ -27,6 +28,10 @@
 
         protected override void Configure()
         {
+            BlobCache.ApplicationName = "ServiceInsight";
+
+            RxServiceControl.Instance = new RxServiceControl(BlobCache.UserAccount);
+
             CreateContainer();
             ExtendConventions();
             ApplyBindingCulture();
@@ -66,7 +71,7 @@
 
         void ExtendConventions()
         {
-            ConventionManager.AddElementConvention<BarButtonItem>(BarButtonItem.IsVisibleProperty, "DataContext", "ItemClick");
+            ConventionManager.AddElementConvention<BarButtonItem>(BarItem.IsVisibleProperty, "DataContext", "ItemClick");
         }
 
         protected override void PrepareApplication()

--- a/src/ServiceInsight/Startup/ConfigurationSettingsReader.cs
+++ b/src/ServiceInsight/Startup/ConfigurationSettingsReader.cs
@@ -1,6 +1,0 @@
-﻿namespace ServiceInsight.Startup
-{
-    public class ConfigurationSettingsReader
-    {
-    }
-}

--- a/src/ServiceInsight/packages.config
+++ b/src/ServiceInsight/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="akavache" version="4.1.2" targetFramework="net45" />
+  <package id="akavache.core" version="4.1.2" targetFramework="net45" />
+  <package id="akavache.sqlite3" version="4.1.2" targetFramework="net45" />
   <package id="Anotar.Serilog.Fody" version="2.16.0.1" targetFramework="net45" developmentDependency="true" />
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.Configuration" version="3.3.0" targetFramework="net45" />
@@ -29,6 +32,8 @@
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
   <package id="Rx-XAML" version="2.2.5" targetFramework="net45" />
   <package id="Serilog" version="1.4.204" targetFramework="net45" />
+  <package id="Splat" version="1.6.2" targetFramework="net45" />
+  <package id="SQLitePCL.raw_basic" version="0.8.6" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Virtuosity.Fody" version="1.19.7.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I've created a reactive ServiceControl interface, which changes the interaction with SC from a pull to a push model. The main benefit here is a single call to SC which then broadcasts the data within SI rather than each viewmodel calling SC independently, which is causing SI to call SC multiple times.

The second part of this change is to rewrite the Endpoint Explorer to use this new interface. This lead to some code simplification.