### PR TITLE
[WIP] Made SC connection provider a singleton

### DIFF
--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -44,19 +44,13 @@
 
             if (root == null)
             {
-                if (!Items.Any())
-                {
-                    root = new ServiceControlExplorerItem(e.Url);
-                    root.IsExpanded = true;
+                root = new ServiceControlExplorerItem(e.Url);
+                root.IsExpanded = true;
 
-                    Items.Add(root);
+                Items.Clear();
+                Items.Add(root);
 
-                    SelectedNode = root;
-                }
-                else
-                {
-                    return;
-                }
+                SelectedNode = root;
             }
 
             var toRemove = root.Children.ToList();

--- a/src/ServiceInsight/Framework/Events/WorkFinished.cs
+++ b/src/ServiceInsight/Framework/Events/WorkFinished.cs
@@ -7,11 +7,6 @@
         {
         }
 
-        public WorkFinished(string format, params object[] args)
-            : this(string.Format(format, args))
-        {
-        }
-
         public WorkFinished(string message)
         {
             Message = message;

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -21,14 +21,16 @@
             builder.RegisterType<HeaderContentDecoder>().As<IContentDecoder<IList<HeaderInfo>>>();
             builder.RegisterType<NetworkOperations>().SingleInstance();
             builder.RegisterType<AppLicenseManager>().SingleInstance();
-            builder.RegisterType<ServiceControlConnectionProvider>().SingleInstance();
-            builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
             builder.RegisterInstance(new RxServiceControl(BlobCache.UserAccount)).As<IRxServiceControl>().SingleInstance();
             builder.RegisterType<CommandLineArgParser>().SingleInstance().OnActivating(e => e.Instance.Parse());
             builder.RegisterType<RxEventAggregator>().As<IRxEventAggregator>().SingleInstance();
             builder.RegisterType<WorkNotifier>().As<IWorkNotifier>();
             builder.RegisterType<WindowManagerEx>().As<IWindowManagerEx>();
             builder.RegisterInstance(PiracRunner.WindowManager).As<IWindowManager>();
+
+            // Scope used to check new SC connection before changing
+            builder.RegisterType<ServiceControlConnectionProvider>().InstancePerLifetimeScope();
+            builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
         }
     }
 }

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -21,7 +21,7 @@
             builder.RegisterType<HeaderContentDecoder>().As<IContentDecoder<IList<HeaderInfo>>>();
             builder.RegisterType<NetworkOperations>().SingleInstance();
             builder.RegisterType<AppLicenseManager>().SingleInstance();
-            builder.RegisterType<ServiceControlConnectionProvider>().InstancePerLifetimeScope();
+            builder.RegisterType<ServiceControlConnectionProvider>().SingleInstance();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
             builder.RegisterInstance(new RxServiceControl(BlobCache.UserAccount)).As<IRxServiceControl>().SingleInstance();
             builder.RegisterType<CommandLineArgParser>().SingleInstance().OnActivating(e => e.Instance.Parse());

--- a/src/ServiceInsight/Framework/WorkNotifier.cs
+++ b/src/ServiceInsight/Framework/WorkNotifier.cs
@@ -9,6 +9,8 @@
         IDisposable NotifyOfWork();
 
         IDisposable NotifyOfWork(string startMessage);
+
+        IDisposable NotifyOfWork(string startMessage, string endMessage);
     }
 
     class WorkNotifier : IWorkNotifier
@@ -32,6 +34,13 @@
             eventAggregator.Publish(new WorkStarted(startMessage));
 
             return Disposable.Create(() => eventAggregator.Publish(new WorkFinished()));
+        }
+
+        public IDisposable NotifyOfWork(string startMessage, string endMessage)
+        {
+            eventAggregator.Publish(new WorkStarted(startMessage));
+
+            return Disposable.Create(() => eventAggregator.Publish(new WorkFinished(endMessage)));
         }
     }
 }

--- a/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
@@ -23,7 +23,7 @@
             AsyncPump.Run(async () =>
             {
                 // TODO turned off clearing old urls to revert #574
-                //await serviceControl.ClearServiceControls();
+                await serviceControl.ClearServiceControls();
                 await serviceControl.AddServiceControl(url);
 
                 // Prime the streams

--- a/src/ServiceInsight/Shell/ShellViewModel.cs
+++ b/src/ServiceInsight/Shell/ShellViewModel.cs
@@ -250,7 +250,8 @@
 
             if (result.GetValueOrDefault(false))
             {
-                eventAggregator.Publish(new WorkFinished("Connected to ServiceControl Version {0}", connectionViewModel.Version));
+                connectionProvider.ConnectTo(connectionViewModel.ServiceUrl);
+                workNotifer.NotifyOfWork("", $"Connected to ServiceControl Version {connectionViewModel.Version}").Dispose();
             }
         }
 


### PR DESCRIPTION
This fixes #574

- ServiceControlConnectionProvider was not a singleton, so each VM had a different instance and when one was updated with the new connection, the others were not updated.
- Changed the EndpointExplorer to replace the root node, which was the partial implementation from before.