### PR TITLE
Refactored WorkStarted/WorkFinished events into a WorkNotifier service.

### DIFF
--- a/src/ServiceInsight.Tests/Framework/WorkNotiferTests.cs
+++ b/src/ServiceInsight.Tests/Framework/WorkNotiferTests.cs
@@ -1,0 +1,72 @@
+﻿namespace ServiceInsight.Tests.Framework
+{
+    using Caliburn.Micro;
+    using NSubstitute;
+    using NUnit.Framework;
+    using ServiceInsight.Framework;
+    using ServiceInsight.Framework.Events;
+
+    public class WorkNotiferTests
+    {
+        const string StartMessage = "StartMessage";
+        const string FinishMessage = "FinishMessage";
+
+        IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
+
+        [SetUp]
+        public void TestInitialize()
+        {
+            eventAggregator = Substitute.For<IEventAggregator>();
+            workNotifier = new WorkNotifier(eventAggregator);
+        }
+
+        [Test]
+        public void WorkNotifierCallsEventsInPairs_DefaultMessagesMatch()
+        {
+            var disposable = workNotifier.NotifyOfWork();
+
+            eventAggregator.Received(1).PublishOnUIThread(Arg.Is<WorkStarted>(s => s.Message == new WorkStarted().Message));
+            eventAggregator.DidNotReceive().PublishOnUIThread(Arg.Any<WorkFinished>());
+
+            eventAggregator.ClearReceivedCalls();
+
+            disposable.Dispose();
+
+            eventAggregator.DidNotReceive().PublishOnUIThread(Arg.Any<WorkStarted>());
+            eventAggregator.Received(1).PublishOnUIThread(Arg.Is<WorkFinished>(s => s.Message == new WorkFinished().Message));
+        }
+
+        [Test]
+        public void WorkNotifierCallsEventsInPairs_StartMessagesMatch()
+        {
+            var disposable = workNotifier.NotifyOfWork(StartMessage);
+
+            eventAggregator.Received(1).PublishOnUIThread(Arg.Is<WorkStarted>(s => s.Message == StartMessage));
+            eventAggregator.DidNotReceive().PublishOnUIThread(Arg.Any<WorkFinished>());
+
+            eventAggregator.ClearReceivedCalls();
+
+            disposable.Dispose();
+
+            eventAggregator.DidNotReceive().PublishOnUIThread(Arg.Any<WorkStarted>());
+            eventAggregator.Received(1).PublishOnUIThread(Arg.Is<WorkFinished>(s => s.Message == new WorkFinished().Message));
+        }
+
+        [Test]
+        public void WorkNotifierCallsEventsInPairs_StartMessagesAndFinishMessagesMatch()
+        {
+            var disposable = workNotifier.NotifyOfWork(StartMessage, FinishMessage);
+
+            eventAggregator.Received(1).PublishOnUIThread(Arg.Is<WorkStarted>(s => s.Message == StartMessage));
+            eventAggregator.DidNotReceive().PublishOnUIThread(Arg.Any<WorkFinished>());
+
+            eventAggregator.ClearReceivedCalls();
+
+            disposable.Dispose();
+
+            eventAggregator.DidNotReceive().PublishOnUIThread(Arg.Any<WorkStarted>());
+            eventAggregator.Received(1).PublishOnUIThread(Arg.Is<WorkFinished>(s => s.Message == FinishMessage));
+        }
+    }
+}

--- a/src/ServiceInsight.Tests/MessageBodyViewModelTests.cs
+++ b/src/ServiceInsight.Tests/MessageBodyViewModelTests.cs
@@ -6,6 +6,7 @@
     using NSubstitute;
     using NUnit.Framework;
     using ReactiveUI.Testing;
+    using ServiceInsight.Framework;
     using ServiceInsight.Framework.Events;
     using ServiceInsight.MessageList;
     using ServiceInsight.MessageViewers;
@@ -19,6 +20,7 @@
     public class MessageBodyViewModelTests
     {
         IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
         IServiceControl serviceControl;
         HexContentViewModel hexContent;
         JsonMessageViewModel jsonContent;
@@ -30,13 +32,14 @@
         public void TestInitialize()
         {
             eventAggregator = Substitute.For<IEventAggregator>();
+            workNotifier = Substitute.For<IWorkNotifier>();
             serviceControl = Substitute.For<IServiceControl>();
             hexContent = Substitute.For<HexContentViewModel>();
             jsonContent = Substitute.For<JsonMessageViewModel>();
             xmlContent = Substitute.For<XmlMessageViewModel>();
             selection = new MessageSelectionContext(eventAggregator);
 
-            messageBodyFunc = () => new MessageBodyViewModel(hexContent, jsonContent, xmlContent, serviceControl, eventAggregator, selection);
+            messageBodyFunc = () => new MessageBodyViewModel(hexContent, jsonContent, xmlContent, serviceControl, eventAggregator, workNotifier, selection);
         }
 
         [Test]

--- a/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
+++ b/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="ConversationsData\PayLoad.cs" />
     <Compile Include="ConversationsData\SequenceDiagramModelCreatorTestsFromJson.cs" />
     <Compile Include="Framework\Attachments.cs" />
+    <Compile Include="Framework\WorkNotiferTests.cs" />
     <Compile Include="Helpers\BinaryObjectCloner.cs" />
     <Compile Include="JsonViewerTests.cs" />
     <Compile Include="MessageBodyViewModelTests.cs" />

--- a/src/ServiceInsight.Tests/ShellViewModelTests.cs
+++ b/src/ServiceInsight.Tests/ShellViewModelTests.cs
@@ -7,6 +7,7 @@
     using NUnit.Framework;
     using Particular.Licensing;
     using ServiceInsight.Explorer.EndpointExplorer;
+    using ServiceInsight.Framework;
     using ServiceInsight.Framework.Events;
     using ServiceInsight.Framework.Licensing;
     using ServiceInsight.Framework.Settings;
@@ -41,6 +42,7 @@
         MessageFlowViewModel messageFlow;
         SagaWindowViewModel sagaWindow;
         IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
         StatusBarManager statusbarManager;
         MessageBodyViewModel messageBodyView;
         MessageHeadersViewModel headerView;
@@ -61,6 +63,7 @@
             messageList = Substitute.For<MessageListViewModel>();
             statusbarManager = Substitute.For<StatusBarManager>();
             eventAggregator = Substitute.For<IEventAggregator>();
+            workNotifier = Substitute.For<IWorkNotifier>();
             messageFlow = Substitute.For<MessageFlowViewModel>();
             sagaWindow = Substitute.For<SagaWindowViewModel>();
             messageBodyView = Substitute.For<MessageBodyViewModel>();
@@ -84,6 +87,7 @@
                         () => Substitute.For<LicenseRegistrationViewModel>(),
                         statusbarManager,
                         eventAggregator,
+                        workNotifier,
                         licenseManager,
                         messageFlow,
                         sagaWindow,

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -16,6 +16,7 @@
         IHandle<RequestSelectingEndpoint>
     {
         IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
         ISettingsProvider settingsProvider;
         IServiceControl serviceControl;
         NetworkOperations networkOperations;
@@ -24,6 +25,7 @@
 
         public EndpointExplorerViewModel(
             IEventAggregator eventAggregator,
+            IWorkNotifier workNotifier,
             ISettingsProvider settingsProvider,
             ServiceControlConnectionProvider connectionProvider,
             CommandLineArgParser commandLineParser,
@@ -31,6 +33,7 @@
             NetworkOperations networkOperations)
         {
             this.eventAggregator = eventAggregator;
+            this.workNotifier = workNotifier;
             this.settingsProvider = settingsProvider;
             this.serviceControl = serviceControl;
             this.networkOperations = networkOperations;
@@ -65,13 +68,12 @@
             var available = ServiceAvailable(configuredConnection);
             var connectTo = available ? configuredConnection : existingConnection;
 
-            eventAggregator.PublishOnUIThread(new WorkStarted("Trying to connect to ServiceControl at {0}", connectTo));
+            using (workNotifier.NotifyOfWork($"Trying to connect to ServiceControl at {connectTo}"))
+            {
+                ConnectToService(connectTo);
 
-            ConnectToService(connectTo);
-
-            SelectDefaultEndpoint();
-
-            eventAggregator.PublishOnUIThread(new WorkFinished());
+                SelectDefaultEndpoint();
+            }
         }
 
         string GetConfiguredAddress()

--- a/src/ServiceInsight/Framework/Events/WorkFinished.cs
+++ b/src/ServiceInsight/Framework/Events/WorkFinished.cs
@@ -7,11 +7,6 @@
         {
         }
 
-        public WorkFinished(string format, params object[] args)
-            : this(string.Format(format, args))
-        {
-        }
-
         public WorkFinished(string message)
         {
             Message = message;

--- a/src/ServiceInsight/Framework/Events/WorkStarted.cs
+++ b/src/ServiceInsight/Framework/Events/WorkStarted.cs
@@ -7,9 +7,9 @@
         {
         }
 
-        public WorkStarted(string message, params object[] args)
+        public WorkStarted(string message)
         {
-            Message = string.Format(message, args);
+            Message = message;
         }
 
         public string Message { get; }

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -21,6 +21,7 @@
             builder.RegisterType<ServiceControlConnectionProvider>().InstancePerLifetimeScope();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
             builder.RegisterType<CommandLineArgParser>().SingleInstance().OnActivating(e => e.Instance.Parse());
+            builder.RegisterType<WorkNotifier>().As<IWorkNotifier>();
         }
     }
 }

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -21,7 +21,7 @@
             builder.RegisterType<ServiceControlConnectionProvider>().InstancePerLifetimeScope();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
             builder.RegisterType<CommandLineArgParser>().SingleInstance().OnActivating(e => e.Instance.Parse());
-            builder.RegisterType<WorkNotifier>().As<IWorkNotifier>().SingleInstance();
+            builder.RegisterType<WorkNotifier>().As<IWorkNotifier>().InstancePerLifetimeScope();
         }
     }
 }

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -21,7 +21,7 @@
             builder.RegisterType<ServiceControlConnectionProvider>().InstancePerLifetimeScope();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerLifetimeScope();
             builder.RegisterType<CommandLineArgParser>().SingleInstance().OnActivating(e => e.Instance.Parse());
-            builder.RegisterType<WorkNotifier>().As<IWorkNotifier>();
+            builder.RegisterType<WorkNotifier>().As<IWorkNotifier>().SingleInstance();
         }
     }
 }

--- a/src/ServiceInsight/Framework/WorkNotifier.cs
+++ b/src/ServiceInsight/Framework/WorkNotifier.cs
@@ -1,0 +1,47 @@
+﻿namespace ServiceInsight.Framework
+{
+    using System;
+    using System.Reactive.Disposables;
+    using Caliburn.Micro;
+    using ServiceInsight.Framework.Events;
+
+    public interface IWorkNotifier
+    {
+        IDisposable NotifyOfWork();
+
+        IDisposable NotifyOfWork(string startMessage);
+
+        IDisposable NotifyOfWork(string startMessage, string finishMessage);
+    }
+
+    class WorkNotifier : IWorkNotifier
+    {
+        IEventAggregator eventAggregator;
+
+        public WorkNotifier(IEventAggregator eventAggregator)
+        {
+            this.eventAggregator = eventAggregator;
+        }
+
+        public IDisposable NotifyOfWork()
+        {
+            eventAggregator.PublishOnUIThread(new WorkStarted());
+
+            return Disposable.Create(() => eventAggregator.PublishOnUIThread(new WorkFinished()));
+        }
+
+        public IDisposable NotifyOfWork(string startMessage)
+        {
+            eventAggregator.PublishOnUIThread(new WorkStarted(startMessage));
+
+            return Disposable.Create(() => eventAggregator.PublishOnUIThread(new WorkFinished()));
+        }
+
+        public IDisposable NotifyOfWork(string startMessage, string finishMessage)
+        {
+            eventAggregator.PublishOnUIThread(new WorkStarted(startMessage));
+
+            return Disposable.Create(() => eventAggregator.PublishOnUIThread(new WorkFinished(finishMessage)));
+        }
+    }
+}

--- a/src/ServiceInsight/MessageViewers/MessageBodyViewModel.cs
+++ b/src/ServiceInsight/MessageViewers/MessageBodyViewModel.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using Caliburn.Micro;
     using ExtensionMethods;
+    using Framework;
     using HexViewer;
     using JsonViewer;
     using ServiceInsight.Framework.Events;
@@ -15,6 +16,7 @@
         IHandle<BodyTabSelectionChanged>
     {
         readonly IServiceControl serviceControl;
+        readonly IWorkNotifier workNotifier;
         readonly IEventAggregator eventAggregator;
         readonly MessageSelectionContext selection;
         static Dictionary<string, MessageContentType> contentTypeMaps;
@@ -37,10 +39,12 @@
             XmlMessageViewModel xmlViewer,
             IServiceControl serviceControl,
             IEventAggregator eventAggregator,
+            IWorkNotifier workNotifier,
             MessageSelectionContext selectionContext)
         {
             this.serviceControl = serviceControl;
             this.eventAggregator = eventAggregator;
+            this.workNotifier = workNotifier;
             selection = selectionContext;
 
             HexViewer = hexViewer;
@@ -126,13 +130,12 @@
                 return;
             }
 
-            eventAggregator.PublishOnUIThread(new WorkStarted("Loading message body..."));
+            using (workNotifier.NotifyOfWork("Loading message body..."))
+            {
+                serviceControl.LoadBody(selection.SelectedMessage);
 
-            serviceControl.LoadBody(selection.SelectedMessage);
-
-            RefreshChildren();
-
-            eventAggregator.PublishOnUIThread(new WorkFinished());
+                RefreshChildren();
+            }
         }
     }
 }

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -18,12 +18,19 @@
         StoredMessage currentMessage;
         string selectedMessageId;
         IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
         IServiceControl serviceControl;
         readonly MessageSelectionContext selection;
 
-        public SagaWindowViewModel(IEventAggregator eventAggregator, IServiceControl serviceControl, IClipboard clipboard, MessageSelectionContext selectionContext)
+        public SagaWindowViewModel(
+            IEventAggregator eventAggregator,
+            IWorkNotifier workNotifier,
+            IServiceControl serviceControl,
+            IClipboard clipboard,
+            MessageSelectionContext selectionContext)
         {
             this.eventAggregator = eventAggregator;
+            this.workNotifier = workNotifier;
             this.serviceControl = serviceControl;
             selection = selectionContext;
             ShowSagaNotFoundWarning = false;
@@ -121,10 +128,8 @@
 
         void RefreshSaga(SagaInfo originatingSaga)
         {
-            try
+            using (workNotifier.NotifyOfWork("Loading message body..."))
             {
-                eventAggregator.PublishOnUIThread(new WorkStarted("Loading message body..."));
-
                 var previousSagaId = Guid.Empty;
 
                 if (Data == null || Data.SagaId != originatingSaga.SagaId)
@@ -171,10 +176,6 @@
                 {
                     RefreshMessageProperties();
                 }
-            }
-            finally
-            {
-                eventAggregator.PublishOnUIThread(new WorkFinished());
             }
         }
 

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -258,6 +258,7 @@
     <Compile Include="DiagramLegend\DiagramLegendViewModel.cs" />
     <Compile Include="ExtensionMethods\JObjectExtensions.cs" />
     <Compile Include="Framework\Behaviors\CommandParameterHelper.cs" />
+    <Compile Include="Framework\WorkNotifier.cs" />
     <Compile Include="Framework\Commands\BaseCommand.cs" />
     <Compile Include="Framework\Commands\ChangeSelectedMessageCommand.cs" />
     <Compile Include="Framework\Commands\CommandsModule.cs" />

--- a/src/ServiceInsight/Shell/ShellViewModel.cs
+++ b/src/ServiceInsight/Shell/ShellViewModel.cs
@@ -10,6 +10,7 @@
     using Explorer;
     using Explorer.EndpointExplorer;
     using ExtensionMethods;
+    using Framework;
     using Framework.Rx;
     using global::ServiceInsight.SequenceDiagram;
     using LogWindow;
@@ -42,6 +43,7 @@
         IAppCommands appCommander;
         IWindowManagerEx windowManager;
         IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
         AppLicenseManager licenseManager;
         ISettingsProvider settingsProvider;
         CommandLineArgParser comandLineArgParser;
@@ -60,6 +62,7 @@
             Func<LicenseRegistrationViewModel> licenceRegistration,
             StatusBarManager statusBarManager,
             IEventAggregator eventAggregator,
+            IWorkNotifier workNotifier,
             AppLicenseManager licenseManager,
             MessageFlowViewModel messageFlow,
             SagaWindowViewModel sagaWindow,
@@ -74,6 +77,7 @@
             this.appCommander = appCommander;
             this.windowManager = windowManager;
             this.eventAggregator = eventAggregator;
+            this.workNotifier = workNotifier;
             this.licenseManager = licenseManager;
             this.settingsProvider = settingsProvider;
             this.comandLineArgParser = comandLineArgParser;
@@ -203,8 +207,10 @@
 
             if (result.GetValueOrDefault(false))
             {
-                EndpointExplorer.ConnectToService(connectionViewModel.ServiceUrl);
-                eventAggregator.PublishOnUIThread(new WorkFinished("Connected to ServiceControl Version {0}", connectionViewModel.Version));
+                using (workNotifier.NotifyOfWork("", $"Connected to ServiceControl Version {connectionViewModel.Version}"))
+                {
+                    EndpointExplorer.ConnectToService(connectionViewModel.ServiceUrl);
+                }
             }
         }
 


### PR DESCRIPTION
This change bundles WorkStarted and WorkFinished notifications into a disposable, to ensure that the WorkFinished event is always sent out. This starts to sort out problems where a WorkFinished event would occur before a WorkStarted, or even without a matching WorkStarted.