### PR TITLE
fix company name

### DIFF
--- a/src/ServiceInsight/Properties/AssemblyInfo.cs
+++ b/src/ServiceInsight/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Windows;
 [assembly: AssemblyDescription("ServiceInsight")]
 [assembly: AssemblyCopyright("Copyright 2013-2016 NServiceBus Ltd. All rights reserved.")]
 [assembly: AssemblyProduct("ServiceInsight")]
-[assembly: AssemblyCompany("Particular Software Incorporated")]
+[assembly: AssemblyCompany("NServiceBus Ltd.")]
 [assembly: InternalsVisibleTo("ServiceInsight.Tests")]
 
 [assembly:ThemeInfo(

--- a/src/ServiceInsight/Properties/AssemblyInfo.tt
+++ b/src/ServiceInsight/Properties/AssemblyInfo.tt
@@ -17,7 +17,7 @@ using System.Windows;
 [assembly: AssemblyDescription("ServiceInsight")]
 [assembly: AssemblyCopyright("Copyright 2013-<#=DateTime.Now.Year#> NServiceBus Ltd. All rights reserved.")]
 [assembly: AssemblyProduct("ServiceInsight")]
-[assembly: AssemblyCompany("Particular Software Incorporated")]
+[assembly: AssemblyCompany("NServiceBus Ltd.")]
 [assembly: InternalsVisibleTo("ServiceInsight.Tests")]
 
 [assembly:ThemeInfo(


### PR DESCRIPTION
AFAIK "Particular Software Incorporated" isn't a thing, and both SC and SP state "NServiceBus Ltd.". It's also the legal entity name used in the copyright.

I really didn't want to label this as a feature, but it does have external effect, so can't be a refactoring.