### PR TITLE
Log threading fix

### DIFF
--- a/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
+++ b/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Reactive.Concurrency;
     using System.Reactive.Linq;
     using Caliburn.Micro;
     using LogWindow;
@@ -30,7 +31,10 @@
                 .WriteTo.Logger(lc => lc
                     .MinimumLevel.Verbose()
                     .Filter.ByIncludingOnly(Matching.FromSource<IServiceControl>())
-                    .WriteTo.Observers(logEvents => logEvents.Do(LogWindowViewModel.LogObserver).ObserveOnDispatcher().Subscribe()))
+                    .WriteTo.Observers(logEvents => logEvents
+                        .ObserveOn(TaskPoolScheduler.Default)
+                        .Do(LogWindowViewModel.LogObserver)
+                        .Subscribe()))
                 .CreateLogger();
         }
 

--- a/src/ServiceInsight/LogWindow/LogWindowView.xaml.cs
+++ b/src/ServiceInsight/LogWindow/LogWindowView.xaml.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Reactive.Linq;
+    using System.Threading;
     using System.Windows;
-    using ReactiveUI;
 
     public partial class LogWindowView
     {
@@ -24,12 +24,9 @@
                 return;
             }
 
-            if (logSubscription != null)
-            {
-                logSubscription.Dispose();
-            }
+            Interlocked.Exchange(ref logSubscription, null)?.Dispose();
 
-            logSubscription = vm.Logs.ItemsAdded.SubscribeOn(RxApp.MainThreadScheduler).Subscribe(_ => richTextBox.ScrollToEnd());
+            logSubscription = vm.Logs.ItemsAdded.Subscribe(_ => richTextBox.ScrollToEnd());
         }
     }
 }

--- a/src/ServiceInsight/LogWindow/LogWindowViewModel.cs
+++ b/src/ServiceInsight/LogWindow/LogWindowViewModel.cs
@@ -31,7 +31,9 @@
             Logs = new ReactiveList<LogMessage>();
 
             textFormatter = new MessageTemplateTextFormatter("{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}", CultureInfo.InvariantCulture);
-            LogObserver.SubscribeOn(RxApp.TaskpoolScheduler).Subscribe(UpdateLog);
+            LogObserver
+                .ObserveOnDispatcher()
+                .Subscribe(UpdateLog);
 
             ClearCommand = this.CreateCommand(Clear);
             CopyCommand = this.CreateCommand(Copy);

--- a/src/ServiceInsight/LogWindow/LoggingRichTextBoxBehavior.cs
+++ b/src/ServiceInsight/LogWindow/LoggingRichTextBoxBehavior.cs
@@ -3,6 +3,7 @@ namespace ServiceInsight.LogWindow
     using System;
     using System.Collections.Specialized;
     using System.Reactive.Linq;
+    using System.Threading;
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Documents;
@@ -59,11 +60,7 @@ namespace ServiceInsight.LogWindow
                 return;
             }
 
-            if (logSubscription != null)
-            {
-                logSubscription.Dispose();
-                logSubscription = null;
-            }
+            Interlocked.Exchange(ref logSubscription, null)?.Dispose();
 
             paragraph.Inlines.Clear();
             foreach (var log in logs)
@@ -73,7 +70,6 @@ namespace ServiceInsight.LogWindow
 
             logSubscription = logs.Changed
                 .Where(e => e.Action == NotifyCollectionChangedAction.Add || e.Action == NotifyCollectionChangedAction.Reset)
-                .SubscribeOn(RxApp.MainThreadScheduler)
                 .Subscribe(ProcessChange);
         }
 


### PR DESCRIPTION
This fixes up the threading in the logging system.

Lesson's learned:
- ObserveOn is almost always the right thing, SubscribeOn is almost always the wrong thing
- `Do` needs the observer scheduler set _before_ `Do` is called