### PR TITLE
[WIP] Displaying <Null> for empty/null property values in SagaView. 

### DIFF
--- a/src/ServiceInsight/Saga/SagaUpdatedValue.cs
+++ b/src/ServiceInsight/Saga/SagaUpdatedValue.cs
@@ -7,12 +7,13 @@
     public class SagaUpdatedValue : PropertyChangedBase
     {
         public const byte MaxValueLength = 30;
+        public const string NullValue = "null";
 
         public SagaUpdatedValue(string sagaName, string propertyName, string propertyValue)
         {
             SagaName = sagaName;
             Name = propertyName;
-            NewValue = propertyValue;
+            NewValue = propertyValue ?? NullValue;
             ShowEntireContentCommand = this.CreateCommand(ShowEntireContent);
         }
 
@@ -53,7 +54,7 @@
 
         public void UpdateOldValue(SagaUpdatedValue oldValueHolder)
         {
-            OldValue = oldValueHolder != null ? oldValueHolder.NewValue : string.Empty;
+            OldValue = oldValueHolder != null ? oldValueHolder.NewValue ?? NullValue : string.Empty;
         }
     }
 }


### PR DESCRIPTION
Resolves #642

The saga data values are are stored as serialized json objects without types information. All the primitive values are received in SI as a string. The lack of value were signified with an empty string, which is now displayed as "<Null>" instead. Given the lack of type information, I think this is the best that could be done.

Here's how it looks now:

![image](https://cloud.githubusercontent.com/assets/132117/20584030/f0a6a41e-b242-11e6-8633-26603a2cadb0.png)

@Particular/serviceinsight-maintainers please review at your convenience. 