### PR TITLE
Code cleanup

### DIFF
--- a/src/ServiceInsight.Tests/Framework/Attachments.cs
+++ b/src/ServiceInsight.Tests/Framework/Attachments.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceInsight.Tests.Framework
 {
-    using System;
     using NUnit.Framework;
     using ServiceInsight.Framework.Attachments;
 

--- a/src/ServiceInsight.Tests/MessageBodyViewModelTests.cs
+++ b/src/ServiceInsight.Tests/MessageBodyViewModelTests.cs
@@ -39,7 +39,7 @@
             xmlContent = Substitute.For<XmlMessageViewModel>();
             selection = new MessageSelectionContext(eventAggregator);
 
-            messageBodyFunc = () => new MessageBodyViewModel(hexContent, jsonContent, xmlContent, serviceControl, eventAggregator, workNotifier, selection);
+            messageBodyFunc = () => new MessageBodyViewModel(hexContent, jsonContent, xmlContent, serviceControl, workNotifier, selection);
         }
 
         [Test]

--- a/src/ServiceInsight.Tests/SearchViewModelTests.cs
+++ b/src/ServiceInsight.Tests/SearchViewModelTests.cs
@@ -15,13 +15,12 @@
     public sealed class SearchViewModelTests : IDisposable
     {
         SearchBarViewModel viewModel;
-        CommandLineArgParser argParser;
-        ISettingsProvider settingProvider;
 
         public SearchViewModelTests()
         {
-            argParser = Substitute.For<CommandLineArgParser>();
-            settingProvider = Substitute.For<ISettingsProvider>();
+            var argParser = Substitute.For<CommandLineArgParser>();
+            var settingProvider = Substitute.For<ISettingsProvider>();
+
             viewModel = new SearchBarViewModel(argParser, settingProvider);
         }
 

--- a/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
+++ b/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
@@ -67,6 +67,10 @@
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ObservablePropertyChanged, Version=0.1.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ObservablePropertyChanged.0.1.3\lib\ObservablePropertyChanged.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="ReactiveUI, Version=5.5.1.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/ServiceInsight.Tests/packages.config
+++ b/src/ServiceInsight.Tests/packages.config
@@ -5,6 +5,7 @@
   <package id="Caliburn.Micro.Core" version="2.0.2" targetFramework="net45" />
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
+  <package id="ObservablePropertyChanged" version="0.1.3" targetFramework="net452" developmentDependency="true" />
   <package id="reactiveui-core" version="5.5.1" targetFramework="net45" />
   <package id="reactiveui-testing" version="5.5.1" targetFramework="net45" />
   <package id="RestSharp" version="105.0.1" targetFramework="net45" />

--- a/src/ServiceInsight/ExtensionMethods/JObjectExtensions.cs
+++ b/src/ServiceInsight/ExtensionMethods/JObjectExtensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceInsight.ExtensionMethods
 {
-    using System;
     using System.IO;
     using System.Text;
     using Newtonsoft.Json;

--- a/src/ServiceInsight/Framework/MessageDecoders/JsonMessageDeserializer.cs
+++ b/src/ServiceInsight/Framework/MessageDecoders/JsonMessageDeserializer.cs
@@ -139,8 +139,10 @@
             {
                 if (elements.Count > 200)
                 {
-                    var missingJObject = new JsonObject();
-                    missingJObject["missing_data"] = true;
+                    var missingJObject = new JsonObject
+                    {
+                        ["missing_data"] = true
+                    };
 
                     elements = elements.Cast<object>().Take(100)
                         .Concat(new[] { missingJObject })

--- a/src/ServiceInsight/LogWindow/LogWindowView.xaml.cs
+++ b/src/ServiceInsight/LogWindow/LogWindowView.xaml.cs
@@ -1,7 +1,6 @@
 ﻿namespace ServiceInsight.LogWindow
 {
     using System;
-    using System.Reactive.Linq;
     using System.Threading;
     using System.Windows;
 

--- a/src/ServiceInsight/MessageFlow/MessageActionPopup.xaml
+++ b/src/ServiceInsight/MessageFlow/MessageActionPopup.xaml
@@ -17,7 +17,7 @@
                     <SolidColorBrush x:Key="GlyphBrush" Color="#444" />
                     <SolidColorBrush x:Key="DisabledForegroundBrush" Color="#888" />
                     <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#000" />
-                    <SolidColorBrush x:Key="SelectedBackgroundBrush" Color="#007AC7" />
+                    <SolidColorBrush x:Key="SelectedNodeBackgroundBrush" Color="#007AC7" />
 
                     <LinearGradientBrush x:Key="NormalBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientBrush.GradientStops>
@@ -150,7 +150,7 @@
                                 <Setter TargetName="Icon" Property="Visibility" Value="Hidden" />
                             </Trigger>
                             <Trigger Property="IsHighlighted" Value="true">
-                                <Setter TargetName="Border" Property="Background" Value="{StaticResource SelectedBackgroundBrush}" />
+                                <Setter TargetName="Border" Property="Background" Value="{StaticResource SelectedNodeBackgroundBrush}" />
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="false">
                                 <Setter Property="Foreground" Value="{StaticResource DisabledForegroundBrush}" />
@@ -210,7 +210,7 @@
                                 <Setter TargetName="Icon" Property="Visibility" Value="Collapsed" />
                             </Trigger>
                             <Trigger Property="IsHighlighted" Value="true">
-                                <Setter TargetName="Border" Property="Background" Value="{StaticResource SelectedBackgroundBrush}" />
+                                <Setter TargetName="Border" Property="Background" Value="{StaticResource SelectedNodeBackgroundBrush}" />
                             </Trigger>
                             <Trigger SourceName="Popup" Property="Popup.AllowsTransparency" Value="True">
                                 <Setter TargetName="SubmenuBorder" Property="CornerRadius" Value="4" />

--- a/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml
+++ b/src/ServiceInsight/MessageHeaders/MessageHeadersView.xaml
@@ -94,22 +94,22 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+        <DataTemplate x:Key="TextTemplate">
+            <TextBlock Text="{Binding Value}" d:DataContext="{d:DesignInstance messageHeaders:MessageHeadersKeyValueList}" />
+        </DataTemplate>
+        
+        <DataTemplate x:Key="ExceptionTemplate">
+            <controls:MvvmTextEditor d:DataContext="{d:DesignInstance messageHeaders:MessageHeadersKeyValueList}"
+                                     FontFamily="Consolas"
+                                     FontSize="10pt"
+                                     IsReadOnly="true"
+                                     ScrollViewer.CanContentScroll="False"
+                                     Style="{StaticResource MvvmTextEditorScrollFixStyle}"
+                                     SyntaxHighlighting="StackTrace"
+                                     Text="{Binding Value}" />
+        </DataTemplate>
     </UserControl.Resources>
     <Grid>
-        <Grid.Resources>
-            <DataTemplate x:Key="TextTemplate">
-                <TextBlock Text="{Binding Value}" />
-            </DataTemplate>
-            <DataTemplate x:Key="ExceptionTemplate">
-                <controls:MvvmTextEditor FontFamily="Consolas"
-                                         FontSize="10pt"
-                                         IsReadOnly="true"
-                                         ScrollViewer.CanContentScroll="False"
-                                         Style="{StaticResource MvvmTextEditorScrollFixStyle}"
-                                         SyntaxHighlighting="StackTrace"
-                                         Text="{Binding Value}" />
-            </DataTemplate>
-        </Grid.Resources>
         <DataGrid Name="gridView"
                   AutoGenerateColumns="False"
                   CanUserAddRows="False"
@@ -127,7 +127,6 @@
                   VerticalScrollBarVisibility="Visible">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Key}" Header="Key" />
-                <!--<DataGridTextColumn Header="Value"  Binding="{Binding Value}"/>-->
                 <DataGridTemplateColumn ClipboardContentBinding="{Binding Value}" Header="Value">
                     <DataGridTemplateColumn.CellTemplateSelector>
                         <messageHeaders:MessageHeaderValueTemplateSelector ExceptionTemplate="{StaticResource ExceptionTemplate}" TextTemplate="{StaticResource TextTemplate}" />

--- a/src/ServiceInsight/MessageHeaders/MessageHeadersViewModel.cs
+++ b/src/ServiceInsight/MessageHeaders/MessageHeadersViewModel.cs
@@ -2,9 +2,9 @@
 {
     using System.Linq;
     using Caliburn.Micro;
+    using Framework.Events;
+    using MessageList;
     using ReactiveUI;
-    using ServiceInsight.Framework.Events;
-    using ServiceInsight.MessageList;
 
     public class MessageHeadersViewModel : Screen, IHandle<SelectedMessageChanged>
     {
@@ -13,10 +13,10 @@
         public MessageHeadersViewModel(MessageSelectionContext selectionContext)
         {
             selection = selectionContext;
-            KeyValues = new ReactiveList<MessageHeaderKeyValue> { ResetChangeThreshold = 0 };
+            KeyValues = new MessageHeadersKeyValueList { ResetChangeThreshold = 0 };
         }
 
-        public ReactiveList<MessageHeaderKeyValue> KeyValues { get; }
+        public MessageHeadersKeyValueList KeyValues { get; }
 
         public void Handle(SelectedMessageChanged @event)
         {
@@ -38,5 +38,9 @@
                 }));
             }
         }
+    }
+
+    public class MessageHeadersKeyValueList : ReactiveList<MessageHeaderKeyValue>
+    {
     }
 }

--- a/src/ServiceInsight/MessageViewers/JsonViewer/JsonMessageView.xaml.cs
+++ b/src/ServiceInsight/MessageViewers/JsonViewer/JsonMessageView.xaml.cs
@@ -1,6 +1,5 @@
 ﻿namespace ServiceInsight.MessageViewers.JsonViewer
 {
-    using System;
     using System.Windows.Media;
     using ICSharpCode.AvalonEdit.Folding;
     using ICSharpCode.AvalonEdit.Indentation;

--- a/src/ServiceInsight/MessageViewers/MessageBodyViewModel.cs
+++ b/src/ServiceInsight/MessageViewers/MessageBodyViewModel.cs
@@ -18,7 +18,6 @@
     {
         readonly IServiceControl serviceControl;
         readonly IWorkNotifier workNotifier;
-        readonly IEventAggregator eventAggregator;
         readonly MessageSelectionContext selection;
         static Dictionary<string, MessageContentType> contentTypeMaps;
 
@@ -39,12 +38,10 @@
             JsonMessageViewModel jsonViewer,
             XmlMessageViewModel xmlViewer,
             IServiceControl serviceControl,
-            IEventAggregator eventAggregator,
             IWorkNotifier workNotifier,
             MessageSelectionContext selectionContext)
         {
             this.serviceControl = serviceControl;
-            this.eventAggregator = eventAggregator;
             this.workNotifier = workNotifier;
             selection = selectionContext;
 

--- a/src/ServiceInsight/MessageViewers/XmlViewer/XmlMessageView.xaml.cs
+++ b/src/ServiceInsight/MessageViewers/XmlViewer/XmlMessageView.xaml.cs
@@ -1,10 +1,7 @@
 ﻿namespace ServiceInsight.MessageViewers.XmlViewer
 {
-    using System;
     using System.Windows.Media;
-    using System.Xml;
     using ICSharpCode.AvalonEdit.Folding;
-    using ServiceInsight.ExtensionMethods;
 
     public partial class XmlMessageView : IXmlMessageView
     {

--- a/src/ServiceInsight/MessageViewers/XmlViewer/XmlMessageViewModel.cs
+++ b/src/ServiceInsight/MessageViewers/XmlViewer/XmlMessageViewModel.cs
@@ -5,7 +5,6 @@
     using System.Xml;
     using System.Xml.Linq;
     using Caliburn.Micro;
-    using ServiceInsight.ExtensionMethods;
     using ServiceInsight.Models;
 
     public class XmlMessageViewModel : Screen, IDisplayMessageBody

--- a/src/ServiceInsight/Shell/About.xaml
+++ b/src/ServiceInsight/Shell/About.xaml
@@ -48,14 +48,14 @@
 
                 <TextBlock Style="{StaticResource InfoText}">
                     <Run Text="Version  " />
-                    <Run Text="{Binding AppVersion}" />
+                    <Run Text="{Binding AppVersion, Mode=OneWay}" />
                     <Run Text="  Commit hash:  " />
-                    <Run Text="{Binding CommitHash}" />
+                    <Run Text="{Binding CommitHash, Mode=OneWay}" />
                 </TextBlock>
 
                 <TextBlock Style="{StaticResource InfoText}" Visibility="{Binding IsSplash, Converter={StaticResource BoolToVisibilityConverterInverted}}">
                     <Run Text="ServiceControl:  " />
-                    <Run Text="{Binding ServiceControlVersion}" />
+                    <Run Text="{Binding ServiceControlVersion, Mode=OneWay}" />
                 </TextBlock>
             </StackPanel>
 

--- a/src/ServiceInsight/Shell/AboutViewModel.cs
+++ b/src/ServiceInsight/Shell/AboutViewModel.cs
@@ -6,9 +6,9 @@ namespace ServiceInsight.Shell
     using System.Reflection;
     using System.Windows.Input;
     using Caliburn.Micro;
-    using ExtensionMethods;
-    using ServiceControl;
+    using ServiceInsight.ExtensionMethods;
     using ServiceInsight.Framework;
+    using ServiceInsight.ServiceControl;
 
     public class AboutViewModel : INotifyPropertyChanged, IActivate, IHaveDisplayName
     {

--- a/src/ServiceInsight/Shell/Shell.xaml
+++ b/src/ServiceInsight/Shell/Shell.xaml
@@ -164,7 +164,7 @@
                                AutomationProperties.AutomationId="RegistrationStatus"
                                CategoryName="Status"
                                Content="{Binding StatusBarManager.Registration,
-                                                 Mode=TwoWay}" />
+                                                 Mode=OneWay}" />
 
             <dxb:BarStaticItem x:Name="Status"
                                AutoSizeMode="Fill"

--- a/src/ServiceInsight/Shell/ShellViewModel.cs
+++ b/src/ServiceInsight/Shell/ShellViewModel.cs
@@ -7,27 +7,26 @@
     using System.Windows.Input;
     using System.Windows.Threading;
     using Caliburn.Micro;
-    using Explorer;
-    using Explorer.EndpointExplorer;
-    using ExtensionMethods;
-    using Framework;
-    using Framework.Rx;
-    using global::ServiceInsight.SequenceDiagram;
-    using LogWindow;
-    using MessageFlow;
-    using MessageHeaders;
-    using MessageList;
-    using MessageProperties;
-    using MessageViewers;
-    using Options;
-    using Saga;
+    using ServiceInsight.Explorer;
+    using ServiceInsight.Explorer.EndpointExplorer;
+    using ServiceInsight.ExtensionMethods;
+    using ServiceInsight.Framework;
     using ServiceInsight.Framework.Events;
     using ServiceInsight.Framework.Licensing;
+    using ServiceInsight.Framework.Rx;
     using ServiceInsight.Framework.Settings;
     using ServiceInsight.Framework.UI.ScreenManager;
-    using Settings;
-    using Startup;
-    using IScreen = Caliburn.Micro.IScreen;
+    using ServiceInsight.LogWindow;
+    using ServiceInsight.MessageFlow;
+    using ServiceInsight.MessageHeaders;
+    using ServiceInsight.MessageList;
+    using ServiceInsight.MessageProperties;
+    using ServiceInsight.MessageViewers;
+    using ServiceInsight.Options;
+    using ServiceInsight.Saga;
+    using ServiceInsight.SequenceDiagram;
+    using ServiceInsight.Settings;
+    using ServiceInsight.Startup;
 
     public class ShellViewModel : RxConductor<IScreen>.Collection.AllActive,
         IHandle<WorkStarted>,


### PR DESCRIPTION
This cleans up a few code issues.

- Cleaning up two-way binding to getter-only properties
- Cleaning up usings
- Removing unused dependencies
- Fixing design-time Resharper and VisualStudio warnings

Each change is a separate commit to allow easier reviews. I can squash them into one after the review.
Please review @Particular/serviceinsight-maintainers 