### PR TITLE
Removing unused code from SagaView

### DIFF
--- a/src/ServiceInsight/Images/Xaml/XamlIcons.xaml
+++ b/src/ServiceInsight/Images/Xaml/XamlIcons.xaml
@@ -163,43 +163,6 @@
             </Canvas>
         </Viewbox>
     </ControlTemplate>
-    <ControlTemplate x:Key="ReceivingEndpoint">
-        <Viewbox Stretch="Uniform">
-            <Canvas Width="14">
-                <Canvas.RenderTransform>
-                    <TransformGroup>
-                        <RotateTransform Angle="180" />
-                        <TranslateTransform X="9" Y="10" />
-                        <ScaleTransform ScaleX="0.7" ScaleY="0.7" />
-                    </TransformGroup>
-                </Canvas.RenderTransform>
-                <Polygon Fill="#FF666666"
-                         FillRule="NonZero"
-                         Points="4,-5.5 4,-2.5 0,-2.5 0,2.5 4,2.5 4,5.5 -7,5.5 -7,-5.5     " />
-                <Polygon Fill="#FF666666"
-                         FillRule="NonZero"
-                         Points="1,1.5 7,1.5 7,-1.5 1,-1.5     " />
-            </Canvas>
-        </Viewbox>
-    </ControlTemplate>
-    <ControlTemplate x:Key="SendingEndpoint">
-        <Viewbox Stretch="Uniform">
-            <Canvas Width="14">
-                <Canvas.RenderTransform>
-                    <TransformGroup>
-                        <TranslateTransform X="9" Y="10" />
-                        <ScaleTransform ScaleX="0.7" ScaleY="0.7" />
-                    </TransformGroup>
-                </Canvas.RenderTransform>
-                <Polygon Fill="#FF666666"
-                         FillRule="NonZero"
-                         Points="4,-5.5 4,-2.5 0,-2.5 0,2.5 4,2.5 4,5.5 -7,5.5 -7,-5.5     " />
-                <Polygon Fill="#FF666666"
-                         FillRule="NonZero"
-                         Points="1,1.5 7,1.5 7,-1.5 1,-1.5     " />
-            </Canvas>
-        </Viewbox>
-    </ControlTemplate>
     <ControlTemplate x:Key="Exception">
         <Viewbox Stretch="Uniform">
             <Canvas Width="17" Height="13">

--- a/src/ServiceInsight/Saga/SagaUpdateControl.xaml
+++ b/src/ServiceInsight/Saga/SagaUpdateControl.xaml
@@ -6,10 +6,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:models="clr-namespace:ServiceInsight.Models"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
-             Background="White"
              d:DataContext="{d:DesignInstance {x:Type local:SagaUpdate}}"
              d:DesignHeight="900"
              d:DesignWidth="900"
+             Background="White"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -39,6 +39,21 @@
                     <Setter.Value>
                         <ControlTemplate TargetType="RadioButton">
                             <StackPanel>
+                                <TextBlock x:Name="contentPresenter"
+                                           Margin="{TemplateBinding Padding}"
+                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Text="{TemplateBinding Content}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="{x:Type TextBlock}">
+                                            <Style.Triggers>
+                                                <Trigger Property="IsMouseOver" Value="True">
+                                                    <Setter Property="TextBlock.TextDecorations" Value="Underline" />
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
                                         <VisualState x:Name="Normal" />
@@ -108,22 +123,6 @@
                                         </VisualState>
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
-
-                                <TextBlock x:Name="contentPresenter"
-                                           Margin="{TemplateBinding Padding}"
-                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Text="{TemplateBinding Content}">
-                                    <TextBlock.Style>
-                                        <Style TargetType="{x:Type TextBlock}">
-                                            <Style.Triggers>
-                                                <Trigger Property="IsMouseOver" Value="True">
-                                                    <Setter Property="TextBlock.TextDecorations" Value="Underline" />
-                                                </Trigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </TextBlock.Style>
-                                </TextBlock>
                             </StackPanel>
                         </ControlTemplate>
                     </Setter.Value>
@@ -168,12 +167,12 @@
             </DataTemplate>
 
             <DataTemplate x:Key="MessageTop">
-                <Grid d:DataContext="{d:DesignInstance {x:Type local:SagaMessage}}">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.Resources>
+                <Border x:Name="NoEndpointsBorder"
+                        MinWidth="220"
+                        d:DataContext="{d:DesignInstance {x:Type local:SagaMessage}}"
+                        Background="{StaticResource MessageBackground}"
+                        Padding="2">
+                    <Border.Resources>
                         <SolidColorBrush x:Key="EndpointBackground" Color="White" />
                         <SolidColorBrush x:Key="EndpointForeground" Color="#666666" />
 
@@ -181,84 +180,61 @@
                             <Setter Property="FontSize" Value="9" />
                             <Setter Property="Foreground" Value="{StaticResource EndpointForeground}" />
                         </Style>
-                    </Grid.Resources>
+                    </Border.Resources>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="40" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
 
-                    <StackPanel x:Name="OriginatingEndPoint"
-                                Grid.Row="0"
-                                Grid.Column="0"
-                                Height="14"
-                                Background="{StaticResource EndpointBackground}"
-                                Orientation="Horizontal"
-                                ToolTip="Sending Endpoint"
-                                Visibility="{Binding ElementName=Surface,
-                                                     Path=DataContext.ShowEndpoints,
-                                                     Converter={StaticResource BoolToVisibilityHiddenConverter}}">
-                        <ContentControl Margin="3,0,3,0" Template="{StaticResource SendingEndpoint}" />
-                        <TextBlock FontSize="10px"
-                                   Style="{StaticResource MessageEndpointText}"
-                                   Text="{Binding OriginatingEndpoint}" />
-                    </StackPanel>
+                        <ContentControl Grid.Column="0"
+                                        Width="20"
+                                        Margin="0,4,0,0"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Template="{StaticResource CommandIcon}"
+                                        ToolTip="Command"
+                                        Visibility="{Binding IsCommandMessage,
+                                                             Converter={StaticResource BoolToVisibilityConverter}}" />
+                        <ContentControl Grid.Column="0"
+                                        Width="22"
+                                        Margin="0,4,0,0"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Template="{StaticResource EventIcon}"
+                                        ToolTip="Event"
+                                        Visibility="{Binding IsEventMessage,
+                                                             Converter={StaticResource BoolToVisibilityConverter}}" />
+                        <ContentControl Grid.Column="0"
+                                        Width="24"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Template="{StaticResource TimeoutIcon}"
+                                        ToolTip="Timeout"
+                                        Visibility="{Binding IsTimeout,
+                                                             Converter={StaticResource BoolToVisibilityConverter}}" />
 
-                    <Border x:Name="NoEndpointsBorder"
-                            Grid.Row="1"
-                            MinWidth="220"
-                            Padding="2"
-                            Background="{StaticResource MessageBackground}">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="40" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-
-                            <ContentControl x:Name="FailedMessageMarker"
-                                            Grid.Column="1"
-                                            HorizontalAlignment="Right"
-                                            VerticalAlignment="Top"
-                                            Style="{StaticResource FailedMessageMarker}" />
-
-                            <ContentControl Grid.Column="0"
-                                            Width="20"
-                                            Margin="0,4,0,0"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            Template="{StaticResource CommandIcon}"
-                                            ToolTip="Command"
-                                            Visibility="{Binding IsCommandMessage,
-                                                                 Converter={StaticResource BoolToVisibilityConverter}}" />
-                            <ContentControl Grid.Column="0"
-                                            Width="22"
-                                            Margin="0,4,0,0"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            Template="{StaticResource EventIcon}"
-                                            ToolTip="Event"
-                                            Visibility="{Binding IsEventMessage,
-                                                                 Converter={StaticResource BoolToVisibilityConverter}}" />
-                            <ContentControl Grid.Column="0"
-                                            Width="24"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            Template="{StaticResource TimeoutIcon}"
-                                            ToolTip="Timeout"
-                                            Visibility="{Binding IsTimeout,
-                                                                 Converter={StaticResource BoolToVisibilityConverter}}" />
-
-                            <StackPanel x:Name="MessageTypeBox"
+                        <ContentControl x:Name="FailedMessageMarker"
                                         Grid.Column="1"
-                                        Margin="0,0,10,0"
-                                        VerticalAlignment="Center">
-                                <TextBlock FontSize="14px"
-                                           FontWeight="Bold"
-                                           Text="{Binding MessageFriendlyTypeName}" />
-                                <TextBlock FontSize="14px" Text="{Binding TimeSent, TargetNullValue='TimeSent value unknown'}" />
-                            </StackPanel>
-                        </Grid>
-                    </Border>
-                </Grid>
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Top"
+                                        Style="{StaticResource FailedMessageMarker}" />
+
+                        <StackPanel x:Name="MessageTypeBox"
+                                    Grid.Column="1"
+                                    Margin="0,0,10,0"
+                                    VerticalAlignment="Center">
+                            <TextBlock FontSize="14px"
+                                       FontWeight="Bold"
+                                       Text="{Binding MessageFriendlyTypeName}" />
+                            <TextBlock FontSize="14px" Text="{Binding TimeSent, TargetNullValue='TimeSent value unknown'}" />
+                        </StackPanel>
+                    </Grid>
+                </Border>
 
                 <DataTemplate.Triggers>
-                    <DataTrigger Binding="{Binding IsSelected}"
-                                 d:DataContext="{d:DesignInstance local:SagaMessage}"
+                    <DataTrigger d:DataContext="{d:DesignInstance local:SagaMessage}"
+                                 Binding="{Binding IsSelected}"
                                  Value="True">
                         <DataTrigger.Setters>
                             <Setter TargetName="NoEndpointsBorder" Property="BorderBrush" Value="Black" />
@@ -270,12 +246,14 @@
             </DataTemplate>
 
             <DataTemplate x:Key="MessageBottom">
-                <Grid d:DataContext="{d:DesignInstance {x:Type local:SagaMessage}}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="40" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
-                    <Grid.Resources>
+                <Border x:Name="MessageDetails"
+                        d:DataContext="{d:DesignInstance {x:Type local:SagaMessage}}"
+                        BorderBrush="{StaticResource MessageBackground}"
+                        BorderThickness="1,0,1,1"
+                        Visibility="{Binding ElementName=Surface,
+                                             Path=DataContext.ShowMessageData,
+                                             Converter={StaticResource BoolToVisibilityConverter}}">
+                    <Border.Resources>
                         <SolidColorBrush x:Key="EndpointBackground" Color="White" />
                         <SolidColorBrush x:Key="EndpointForeground" Color="#666666" />
 
@@ -283,50 +261,24 @@
                             <Setter Property="FontSize" Value="9" />
                             <Setter Property="Foreground" Value="{StaticResource EndpointForeground}" />
                         </Style>
-                    </Grid.Resources>
+                    </Border.Resources>
 
-                    <Border x:Name="MessageDetails"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            BorderBrush="{StaticResource MessageBackground}"
-                            BorderThickness="1,0,1,1"
-                            Visibility="{Binding ElementName=Surface,
-                                                 Path=DataContext.ShowMessageData,
-                                                 Converter={StaticResource BoolToVisibilityConverter}}">
-                        <StackPanel x:Name="MessageDataPanel" Visibility="{Binding ElementName=Surface, Path=DataContext.ShowMessageData, Converter={StaticResource BoolToVisibilityConverter}}">
-                            <ItemsControl x:Name="MessageData"
-                                          Padding="4"
-                                          ItemTemplate="{StaticResource MessageDataItem}"
-                                          ItemsSource="{Binding Data}" />
-                            <TextBlock x:Name="EmptyPropertyText"
-                                       HorizontalAlignment="Center"
-                                       Foreground="Black"
-                                       Text="Empty"
-                                       Visibility="Collapsed" />
-                        </StackPanel>
-                    </Border>
-
-                    <StackPanel x:Name="ReceivingEndPoint"
-                                Grid.Column="0"
-                                Grid.ColumnSpan="2"
-                                Height="14"
-                                VerticalAlignment="Center"
-                                Background="{StaticResource EndpointBackground}"
-                                Orientation="Horizontal"
-                                ToolTip="Processing Endpoint"
-                                Visibility="{Binding ElementName=Surface,
-                                                     Path=DataContext.ShowEndpoints,
-                                                     Converter={StaticResource BoolToVisibilityConverter}}">
-                        <ContentControl Margin="3,0,3,0" Template="{StaticResource ReceivingEndpoint}" />
-                        <TextBlock FontSize="10px"
-                                   Style="{StaticResource MessageEndpointText}"
-                                   Text="{Binding ReceivingEndpoint}" />
+                    <StackPanel x:Name="MessageDataPanel" Visibility="{Binding ElementName=Surface, Path=DataContext.ShowMessageData, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <ItemsControl x:Name="MessageData"
+                                      ItemTemplate="{StaticResource MessageDataItem}"
+                                      ItemsSource="{Binding Data}"
+                                      Padding="4" />
+                        <TextBlock x:Name="EmptyPropertyText"
+                                   HorizontalAlignment="Center"
+                                   Foreground="Black"
+                                   Text="Empty"
+                                   Visibility="Collapsed" />
                     </StackPanel>
-                </Grid>
+                </Border>
 
                 <DataTemplate.Triggers>
-                    <DataTrigger Binding="{Binding ShowData}"
-                                 d:DataContext="{d:DesignInstance local:SagaMessage}"
+                    <DataTrigger d:DataContext="{d:DesignInstance local:SagaMessage}"
+                                 Binding="{Binding ShowData}"
                                  Value="False">
                         <DataTrigger.Setters>
                             <Setter TargetName="EmptyPropertyText" Property="Visibility" Value="{Binding ElementName=Surface, Path=DataContext.ShowMessageData, Converter={StaticResource BoolToVisibilityConverter}}" />
@@ -336,10 +288,7 @@
             </DataTemplate>
 
             <DataTemplate x:Key="Message">
-                <Border x:Name="EndpointsBorder"
-                        BorderBrush="Black"
-                        BorderThickness="0"
-                        d:DataContext="{d:DesignInstance {x:Type local:SagaMessage}}">
+                <Border x:Name="EndpointsBorder" d:DataContext="{d:DesignInstance {x:Type local:SagaMessage}}">
                     <Grid x:Name="RootGrid"
                           Focusable="True"
                           MouseLeftButtonUp="RootGrid_MouseLeftButtonUp">
@@ -355,20 +304,10 @@
                                         ContentTemplate="{StaticResource MessageBottom}" />
                     </Grid>
                 </Border>
-
-                <DataTemplate.Triggers>
-                    <MultiDataTrigger d:DataContext="{d:DesignInstance local:SagaMessage}">
-                        <MultiDataTrigger.Conditions>
-                            <Condition Binding="{Binding ElementName=Surface, Path=DataContext.ShowEndpoints}" Value="True" />
-                            <Condition Binding="{Binding IsSelected}" Value="True" />
-                        </MultiDataTrigger.Conditions>
-                        <Setter TargetName="EndpointsBorder" Property="BorderThickness" Value="2" />
-                    </MultiDataTrigger>
-                </DataTemplate.Triggers>
             </DataTemplate>
 
             <DataTemplate x:Key="UpdatedValuesTemplate">
-                <Grid Background="{StaticResource SagaBackground}" d:DataContext="{d:DesignInstance local:SagaUpdatedValue}">
+                <Grid d:DataContext="{d:DesignInstance local:SagaUpdatedValue}" Background="{StaticResource SagaBackground}">
                     <StackPanel Margin="0 6 0 0"
                                 Orientation="Horizontal"
                                 Visibility="{Binding IsValueChanged,
@@ -449,8 +388,8 @@
 
             <DataTemplate x:Key="AllValuesTemplate">
                 <Grid x:Name="AllValuesRoot"
-                      Background="{StaticResource SagaBackground}"
-                      d:DataContext="{d:DesignInstance local:SagaUpdatedValue}">
+                      d:DataContext="{d:DesignInstance local:SagaUpdatedValue}"
+                      Background="{StaticResource SagaBackground}">
                     <ContentPresenter ContentSource="{Binding}" ContentTemplate="{StaticResource UpdatedValuesTemplate}" />
                     <StackPanel Margin="0 6 0 0"
                                 Orientation="Horizontal"
@@ -509,9 +448,10 @@
                                                 VerticalAlignment="Top"
                                                 Template="{StaticResource SagaTimeoutIcon}" />
 
-                                <TextBlock Visibility="{Binding HasBeenProcessed,Converter={StaticResource BoolToVisibilityConverter}}"
-                                        FontSize="16px"
-                                        FontWeight="Bold">
+                                <TextBlock FontSize="16px"
+                                           FontWeight="Bold"
+                                           Visibility="{Binding HasBeenProcessed,
+                                                                Converter={StaticResource BoolToVisibilityConverter}}">
                                     <Hyperlink Click="Hyperlink_Click" Foreground="{StaticResource SagaBlue}">
                                         <InlineUIContainer>
                                             <TextBlock Text="Timeout Requested = " />
@@ -521,9 +461,10 @@
                                         </InlineUIContainer>
                                     </Hyperlink>
                                 </TextBlock>
-                                <TextBlock Visibility="{Binding HasBeenProcessed,Converter={StaticResource BoolToVisibilityConverterInverted}}"
-                                        FontSize="16px"
-                                        FontWeight="Bold">
+                                <TextBlock FontSize="16px"
+                                           FontWeight="Bold"
+                                           Visibility="{Binding HasBeenProcessed,
+                                                                Converter={StaticResource BoolToVisibilityConverterInverted}}">
                                     <InlineUIContainer>
                                         <TextBlock Text="Timeout Requested = " />
                                     </InlineUIContainer>
@@ -642,18 +583,6 @@
                 <ContentPresenter Content="{Binding InitiatingMessage}" ContentTemplate="{StaticResource MessageTop}" />
             </Grid>
 
-            <Grid x:Name="InitialMessageBottom"
-                  Grid.Row="1"
-                  HorizontalAlignment="Right"
-                  VerticalAlignment="Top">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" SharedSizeGroup="InitialMessageColumn" />
-                </Grid.ColumnDefinitions>
-                <Border BorderBrush="Black" BorderThickness="0 2 0 0">
-                    <ContentPresenter Content="{Binding InitiatingMessage}" ContentTemplate="{StaticResource MessageBottom}" />
-                </Border>
-            </Grid>
-
             <Border x:Name="Middle"
                     Grid.Column="1"
                     Background="{StaticResource SagaBackground}">
@@ -689,6 +618,18 @@
                     </StackPanel>
                 </StackPanel>
             </Border>
+
+            <Grid x:Name="InitialMessageBottom"
+                  Grid.Row="1"
+                  HorizontalAlignment="Right"
+                  VerticalAlignment="Top">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" SharedSizeGroup="InitialMessageColumn" />
+                </Grid.ColumnDefinitions>
+                <Border BorderBrush="Black" BorderThickness="0 2 0 0">
+                    <ContentPresenter Content="{Binding InitiatingMessage}" ContentTemplate="{StaticResource MessageBottom}" />
+                </Border>
+            </Grid>
 
             <Grid x:Name="Properties"
                   Grid.Row="1"
@@ -772,7 +713,6 @@
                              Stretch="Fill" />
 
                     <ItemsControl Grid.Row="2"
-                                  Margin="0 -15 0 0"
                                   HorizontalAlignment="Center"
                                   ItemTemplate="{StaticResource Message}"
                                   ItemsSource="{Binding NonTimeoutMessages}" />

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -249,8 +249,6 @@
 
         public SagaFooter Footer { get; private set; }
 
-        public bool ShowEndpoints { get; set; }
-
         public bool ShowMessageData { get; set; }
 
         public void ShowFlow()


### PR DESCRIPTION
As part of #657 I discovered 2 icons that did not work properly. This lead me to investigating the SagaView and I found there was a bit of code that was related to showing endpoints, except the bool controlling this code is never changed, and so all this xaml is never used.