### PR TITLE
Search using RestSharp parameters

### DIFF
--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -13,7 +13,6 @@
     using Caliburn.Micro;
     using Framework;
     using RestSharp;
-    using RestSharp.Contrib;
     using RestSharp.Deserializers;
     using Serilog;
     using ServiceInsight.ExtensionMethods;
@@ -210,7 +209,8 @@
                 return;
             }
 
-            request.Resource += string.Format("search?q={0}", HttpUtility.UrlEncode(searchQuery));
+            request.Resource += "search";
+            request.AddParameter("q", searchQuery, ParameterType.GetOrPost);
         }
 
         IRestClient CreateClient(string baseUrl = null)


### PR DESCRIPTION
A followup to #687 to use RestSharp's parameters instead of string manipulation.

Fixes #639.