### PR TITLE
Use SC-generated paging links to page the audit message data

### DIFF
--- a/src/ServiceInsight.Tests/MessageListViewModelTests.cs
+++ b/src/ServiceInsight.Tests/MessageListViewModelTests.cs
@@ -51,7 +51,7 @@
         public void Should_load_the_messages_from_the_endpoint()
         {
             var endpoint = new Endpoint { Host = "localhost", Name = "Service" };
-            serviceControl.GetAuditMessages(Arg.Is(endpoint), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<bool>())
+            serviceControl.GetAuditMessages(Arg.Is(endpoint), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
                 .Returns(x => new PagedResult<StoredMessage>
                 {
                     CurrentPage = 1,

--- a/src/ServiceInsight.sln.DotSettings
+++ b/src/ServiceInsight.sln.DotSettings
@@ -562,6 +562,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	
 	

--- a/src/ServiceInsight/MessageList/MessageListView.xaml.cs
+++ b/src/ServiceInsight/MessageList/MessageListView.xaml.cs
@@ -60,7 +60,10 @@
 
         void SortData(ColumnBase column, ListSortDirection order)
         {
-            Model.RefreshMessages(column.Tag as string, order == ListSortDirection.Ascending);
+            var orderBy = column.Tag as string;
+            var ascending = order == ListSortDirection.Ascending;
+
+            Model.RefreshMessages(orderBy, ascending);
         }
 
         void Grid_OnCustomColumnDisplayText(object sender, CustomColumnDisplayTextEventArgs e)

--- a/src/ServiceInsight/MessageList/MessageListViewModel.cs
+++ b/src/ServiceInsight/MessageList/MessageListViewModel.cs
@@ -151,7 +151,6 @@
                     return;
                 }
 
-                pagedResult.CurrentPage = 1;
                 TryRebindMessageList(pagedResult);
 
                 SearchBar.IsVisible = true;

--- a/src/ServiceInsight/MessageList/MessageListViewModel.cs
+++ b/src/ServiceInsight/MessageList/MessageListViewModel.cs
@@ -37,8 +37,8 @@
         IWorkNotifier workNotifier;
         IServiceControl serviceControl;
         GeneralHeaderViewModel generalHeaderDisplay;
-        string lastSortColumn;
-        bool lastSortOrderAscending;
+        string sortColumn;
+        bool sortOrderAscending;
         IMessageListView view;
         ExplorerItem selectedExplorerItem;
 
@@ -104,76 +104,59 @@
             clipboard.CopyTo(generalHeaderDisplay.HeaderContent);
         }
 
-        public void RefreshMessages(string orderBy = null, bool ascending = false)
+        public void NavigateToPage(string link, int pageIndex)
         {
-            var serviceControlExplorerItem = selectedExplorerItem as ServiceControlExplorerItem;
-            if (serviceControlExplorerItem != null)
+            using (workNotifier.NotifyOfWork("Loading messages..."))
             {
-                RefreshMessages(searchQuery: SearchBar.SearchQuery,
-                                     endpoint: null,
-                                     orderBy: orderBy,
-                                     ascending: ascending);
-            }
-
-            var endpointNode = selectedExplorerItem as AuditEndpointExplorerItem;
-            if (endpointNode != null)
-            {
-                RefreshMessages(searchQuery: SearchBar.SearchQuery,
-                                     endpoint: endpointNode.Endpoint,
-                                     orderBy: orderBy,
-                                     ascending: ascending);
-            }
-        }
-
-        public void RefreshMessages(Endpoint endpoint, int pageIndex = 1, string searchQuery = null, string orderBy = null, bool ascending = false)
-        {
-            using (workNotifier.NotifyOfWork($"Loading {(endpoint == null ? "all" : endpoint.Address)} messages..."))
-            {
-                if (orderBy != null)
-                {
-                    lastSortColumn = orderBy;
-                    lastSortOrderAscending = ascending;
-                }
-
-                PagedResult<StoredMessage> pagedResult;
-
-                if (endpoint != null)
-                {
-                    pagedResult = serviceControl.GetAuditMessages(endpoint,
-                        pageIndex: pageIndex,
-                        searchQuery: searchQuery,
-                        orderBy: lastSortColumn,
-                        ascending: lastSortOrderAscending);
-                }
-                else if (!searchQuery.IsEmpty())
-                {
-                    pagedResult = serviceControl.Search(pageIndex: pageIndex,
-                        searchQuery: searchQuery,
-                        orderBy: lastSortColumn,
-                        ascending: lastSortOrderAscending);
-                }
-                else
-                {
-                    pagedResult = serviceControl.Search(pageIndex: pageIndex,
-                        searchQuery: null,
-                        orderBy: lastSortColumn,
-                        ascending: lastSortOrderAscending);
-                }
+                var pagedResult = serviceControl.GetAuditMessages(link);
 
                 if (pagedResult == null)
                 {
                     return;
                 }
 
+                pagedResult.CurrentPage = pageIndex;
                 TryRebindMessageList(pagedResult);
 
                 SearchBar.IsVisible = true;
-                SearchBar.SetupPaging(new PagedResult<StoredMessage>
+                SearchBar.SetupPaging(pagedResult);
+            }
+        }
+
+        public void RefreshMessages(string orderBy, bool ascending)
+        {
+            sortColumn = orderBy;
+            sortOrderAscending = ascending;
+            RefreshMessages();
+        }
+
+        public void RefreshMessages()
+        {
+            var endpointNode = selectedExplorerItem as AuditEndpointExplorerItem;
+
+            Search(searchQuery: SearchBar.SearchQuery, endpoint: endpointNode?.Endpoint);
+        }
+
+        public void Search(Endpoint endpoint, string searchQuery = null)
+        {
+            using (workNotifier.NotifyOfWork($"Loading {(endpoint == null ? "all" : endpoint.Address)} messages..."))
+            {
+                var pagedResult = serviceControl.GetAuditMessages(
+                    endpoint,
+                    searchQuery,
+                    sortColumn,
+                    sortOrderAscending);
+
+                if (pagedResult == null)
                 {
-                    CurrentPage = pagedResult.CurrentPage,
-                    TotalCount = pagedResult.TotalCount,
-                    Result = pagedResult.Result,
-                });
+                    return;
+                }
+
+                pagedResult.CurrentPage = 1;
+                TryRebindMessageList(pagedResult);
+
+                SearchBar.IsVisible = true;
+                SearchBar.SetupPaging(pagedResult);
             }
         }
 

--- a/src/ServiceInsight/MessageList/MessageListViewModel.cs
+++ b/src/ServiceInsight/MessageList/MessageListViewModel.cs
@@ -104,7 +104,7 @@
             clipboard.CopyTo(generalHeaderDisplay.HeaderContent);
         }
 
-        public void NavigateToPage(string link, int pageIndex)
+        public void NavigateToPage(string link)
         {
             using (workNotifier.NotifyOfWork("Loading messages..."))
             {
@@ -115,7 +115,6 @@
                     return;
                 }
 
-                pagedResult.CurrentPage = pageIndex;
                 TryRebindMessageList(pagedResult);
 
                 SearchBar.IsVisible = true;

--- a/src/ServiceInsight/Models/PagedResult.cs
+++ b/src/ServiceInsight/Models/PagedResult.cs
@@ -13,6 +13,16 @@
 
         public int TotalCount { get; set; }
 
+        public int PageSize { get; set; }
+
         public int CurrentPage { get; set; }
+
+        public string FirstLink { get; set; }
+
+        public string LastLink { get; set; }
+
+        public string NextLink { get; set; }
+
+        public string PrevLink { get; set; }
     }
 }

--- a/src/ServiceInsight/Search/SearchBarView.xaml
+++ b/src/ServiceInsight/Search/SearchBarView.xaml
@@ -69,7 +69,6 @@
             <Button Content="3" cal:Message.Attach="[Event Click]=[Action GoToPreviousPage]" />
             <TextBlock Text="Page" />
             <TextBlock Text="{Binding CurrentPage}" />
-            <TextBlock Text="{Binding PageCount, StringFormat=of {0}}" />
             <Button Content="4" cal:Message.Attach="[Event Click]=[Action GoToNextPage]" />
             <Button Content=":" cal:Message.Attach="[Event Click]=[Action GoToLastPage]" />
         </StackPanel>

--- a/src/ServiceInsight/Search/SearchBarViewModel.cs
+++ b/src/ServiceInsight/Search/SearchBarViewModel.cs
@@ -51,22 +51,22 @@
 
         public void GoToFirstPage()
         {
-            Parent.NavigateToPage(FirstLink, 1);
+            Parent.NavigateToPage(FirstLink);
         }
 
         public void GoToPreviousPage()
         {
-            Parent.NavigateToPage(PrevLink, CurrentPage - 1);
+            Parent.NavigateToPage(PrevLink);
         }
 
         public void GoToNextPage()
         {
-            Parent.NavigateToPage(NextLink, CurrentPage + 1);
+            Parent.NavigateToPage(NextLink);
         }
 
         public void GoToLastPage()
         {
-            Parent.NavigateToPage(LastLink, PageCount);
+            Parent.NavigateToPage(LastLink);
         }
 
         public ICommand SearchCommand { get; }
@@ -135,19 +135,6 @@
 
         public new MessageListViewModel Parent => base.Parent as MessageListViewModel;
 
-        public int PageCount
-        {
-            get
-            {
-                if (TotalItemCount == 0 || PageSize == 0)
-                {
-                    return 0;
-                }
-
-                return (int)Math.Ceiling((double)TotalItemCount / PageSize);
-            }
-        }
-
         public bool WorkInProgress => workCount > 0;
 
         public Endpoint SelectedEndpoint { get; private set; }
@@ -198,7 +185,6 @@
 
         public void NotifyPropertiesChanged()
         {
-            NotifyOfPropertyChange(nameof(PageCount));
             NotifyOfPropertyChange(nameof(CanGoToFirstPage));
             NotifyOfPropertyChange(nameof(CanGoToLastPage));
             NotifyOfPropertyChange(nameof(CanGoToNextPage));

--- a/src/ServiceInsight/Search/SearchBarViewModel.cs
+++ b/src/ServiceInsight/Search/SearchBarViewModel.cs
@@ -32,7 +32,6 @@
         {
             this.commandLineArgParser = commandLineArgParser;
             this.settingProvider = settingProvider;
-            PageSize = 50; //NOTE: Do we need to change this?
 
             SearchCommand = Command.Create(this, Search, vm => vm.CanSearch);
             CancelSearchCommand = Command.Create(this, CancelSearch, vm => vm.CanCancelSearch);
@@ -52,22 +51,22 @@
 
         public void GoToFirstPage()
         {
-            Parent.RefreshMessages(SelectedEndpoint, 1, SearchQuery);
+            Parent.NavigateToPage(FirstLink, 1);
         }
 
         public void GoToPreviousPage()
         {
-            Parent.RefreshMessages(SelectedEndpoint, CurrentPage - 1, SearchQuery);
+            Parent.NavigateToPage(PrevLink, CurrentPage - 1);
         }
 
         public void GoToNextPage()
         {
-            Parent.RefreshMessages(SelectedEndpoint, CurrentPage + 1, SearchQuery);
+            Parent.NavigateToPage(NextLink, CurrentPage + 1);
         }
 
         public void GoToLastPage()
         {
-            Parent.RefreshMessages(SelectedEndpoint, PageCount, SearchQuery);
+            Parent.NavigateToPage(LastLink, PageCount);
         }
 
         public ICommand SearchCommand { get; }
@@ -87,26 +86,38 @@
             }
         }
 
+        /// <summary>
+        /// Explicit so that binding convension with "Can*" works correctly
+        /// </summary>
+        public void RefreshResult()
+        {
+            Search();
+        }
+
         public void Search()
         {
             SearchInProgress = true;
             AddRecentSearchEntry(SearchQuery);
-            Parent.RefreshMessages(SelectedEndpoint, 1, SearchQuery);
+            Parent.Search(SelectedEndpoint, SearchQuery);
         }
 
         public void CancelSearch()
         {
             SearchQuery = null;
             SearchInProgress = false;
-            Parent.RefreshMessages(SelectedEndpoint, 1, SearchQuery);
+            Parent.Search(SelectedEndpoint, SearchQuery);
         }
 
         public void SetupPaging(PagedResult<StoredMessage> pagedResult)
         {
-            Result = pagedResult.Result;
             CurrentPage = pagedResult.TotalCount > 0 ? pagedResult.CurrentPage : 0;
             TotalItemCount = pagedResult.TotalCount;
-
+            Result = pagedResult.Result;
+            NextLink = pagedResult.NextLink;
+            PrevLink = pagedResult.PrevLink;
+            FirstLink = pagedResult.FirstLink;
+            LastLink = pagedResult.LastLink;
+            PageSize = pagedResult.PageSize;
             NotifyPropertiesChanged();
         }
 
@@ -120,13 +131,6 @@
             SelectedEndpoint = null;
         }
 
-        public void RefreshResult()
-        {
-            Parent.RefreshMessages(SelectedEndpoint, CurrentPage, SearchQuery);
-        }
-
-        public bool CanGoToLastPage => CurrentPage < PageCount && !WorkInProgress;
-
         public bool CanCancelSearch => SearchInProgress;
 
         public new MessageListViewModel Parent => base.Parent as MessageListViewModel;
@@ -135,7 +139,7 @@
         {
             get
             {
-                if (TotalItemCount == 0)
+                if (TotalItemCount == 0 || PageSize == 0)
                 {
                     return 0;
                 }
@@ -158,11 +162,13 @@
 
         public bool IsVisible { get; set; }
 
-        public bool CanGoToFirstPage => CurrentPage > 1 && !WorkInProgress;
+        public bool CanGoToFirstPage => FirstLink != null && !WorkInProgress;
 
-        public bool CanGoToPreviousPage => CurrentPage - 1 >= 1 && !WorkInProgress;
+        public bool CanGoToLastPage => LastLink != null && !WorkInProgress;
 
-        public bool CanGoToNextPage => CurrentPage + 1 <= PageCount && !WorkInProgress;
+        public bool CanGoToPreviousPage => PrevLink != null && !WorkInProgress;
+
+        public bool CanGoToNextPage => NextLink != null && !WorkInProgress;
 
         public IList<StoredMessage> Result { get; private set; }
 
@@ -170,7 +176,15 @@
 
         public int CurrentPage { get; private set; }
 
-        public int PageSize { get; }
+        public string NextLink { get; private set; }
+
+        public string PrevLink { get; private set; }
+
+        public string FirstLink { get; private set; }
+
+        public string LastLink { get; private set; }
+
+        public int PageSize { get; private set; }
 
         public int TotalItemCount { get; private set; }
 

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -110,7 +110,7 @@
 
         public PagedResult<StoredMessage> GetAuditMessages(string link)
         {
-            if (link.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            if (IsAbsoluteUrl(link))
             {
                 var request = new RestRequestWithCache("", RestRequestWithCache.CacheStyle.IfNotModified);
                 return GetPagedResult<StoredMessage>(request, link);
@@ -186,7 +186,7 @@
             request.AddParameter("include_system_messages", settings.DisplaySystemMessages);
         }
 
-        void AppendOrdering(IRestRequest request, string orderBy, bool ascending)
+        static void AppendOrdering(IRestRequest request, string orderBy, bool ascending)
         {
             if (orderBy == null)
             {
@@ -197,7 +197,7 @@
             request.AddParameter("direction", ascending ? "asc" : "desc", ParameterType.GetOrPost);
         }
 
-        void AppendPaging(IRestRequest request)
+        static void AppendPaging(IRestRequest request)
         {
             request.AddParameter("per_page", DefaultPageSize, ParameterType.GetOrPost);
         }
@@ -578,6 +578,11 @@ where T : class, new() => Execute<T, T>(request, response => response.Data);
 
             eventAggregator.PublishOnUIThread(new AsyncOperationFailed(errorMessage));
             LogTo.Error(exception, errorMessage);
+        }
+
+        static bool IsAbsoluteUrl(string url)
+        {
+            return Uri.TryCreate(url, UriKind.Absolute, out _);
         }
 
         static bool HasSucceeded(IRestResponse response) => successCodes.Any(x => response != null && x == response.StatusCode && response.ErrorException == null);

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -14,6 +14,7 @@
     using Caliburn.Micro;
     using Framework;
     using RestSharp;
+    using RestSharp.Contrib;
     using RestSharp.Deserializers;
     using Serilog;
     using ServiceInsight.ExtensionMethods;
@@ -255,20 +256,40 @@
                     linksByRel.TryGetValue("first", out first);
                 }
 
+                var requestUri = baseUrl ?? request.Resource;
+                var requestQueryParameters = HttpUtility.ParseQueryString(requestUri);
+
                 var pageSize = DefaultPageSize;
+                var pageSizeAsString = requestQueryParameters["per_page"];
+                if (pageSizeAsString != null)
+                {
+                    pageSize = int.Parse(pageSizeAsString);
+                }
                 var pageSizeText = (string)response.Headers.FirstOrDefault(x => x.Name == ServiceControlHeaders.PageSize)?.Value;
                 if (pageSizeText != null)
                 {
                     pageSize = int.Parse(pageSizeText);
                 }
+
+                var currentPage = 0;
+                var currentPageAsString = requestQueryParameters["page"];
+                if (currentPageAsString != null)
+                {
+                    currentPage = int.Parse(currentPageAsString);
+                }
+
+                var totalCount = int.Parse(response.Headers.First(x => x.Name == ServiceControlHeaders.TotalCount).Value.ToString());
+                var responseData = response.Data;
+
                 return new PagedResult<T>
                 {
-                    Result = response.Data,
+                    CurrentPage = currentPage,
+                    Result = responseData,
                     NextLink = next,
                     PrevLink = prev,
                     LastLink = last,
                     FirstLink = first,
-                    TotalCount = int.Parse(response.Headers.First(x => x.Name == ServiceControlHeaders.TotalCount).Value.ToString()),
+                    TotalCount = totalCount,
                     PageSize = pageSize
                 };
             }, baseUrl);

--- a/src/ServiceInsight/ServiceControl/IServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/IServiceControl.cs
@@ -17,9 +17,9 @@ namespace ServiceInsight.ServiceControl
 
         SagaData GetSagaById(Guid sagaId);
 
-        PagedResult<StoredMessage> Search(string searchQuery, int pageIndex = 1, string orderBy = null, bool ascending = false);
+        PagedResult<StoredMessage> GetAuditMessages(Endpoint endpoint, string searchQuery = null, string orderBy = null, bool ascending = false);
 
-        PagedResult<StoredMessage> GetAuditMessages(Endpoint endpoint, string searchQuery = null, int pageIndex = 1, string orderBy = null, bool ascending = false);
+        PagedResult<StoredMessage> GetAuditMessages(string link);
 
         IEnumerable<StoredMessage> GetConversationById(string conversationId);
 
@@ -34,5 +34,7 @@ namespace ServiceInsight.ServiceControl
     {
         public const string ParticularVersion = "X-Particular-Version";
         public const string TotalCount = "Total-Count";
+        public const string Link = "Link";
+        public const string PageSize = "Page-Size";
     }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1650

SC generates `Link` header which contains up to 4 links: next, prev, first and last. These are used, instead of generating the links in SI, to page through the data.

The main benefit is making SI not dependent on the actual paging URL format of SC. The SI only needs to know how to initiate the search.

The actual goal is to be able to insert an intermediary between SI and SC. That intermediary could aggregate the results from multiple instances of SC without SI even knowing about its existence.

Also contains small refactorings to SC gateway.

Also solves #736

### Page Count

As part of the TF work of extending SC with the multi instance mode for audits we discovered that the page count is not possible to determine upfront by doing a simple calculation based on the assumed page size. Since we went from a simplified paging approach in contrast to keep the offsets per SC instance each page can return up to `numberOfInstance * page_size` worth of data. Audits cannot be assumed to be uniformly distributed. Based on that we figured having a page size visible at all time makes no sense. The ability to page through the data is more important than knowing how many pages there are.

---

Fixes #736