### PR TITLE
No longer assume object is properly hydrated

### DIFF
--- a/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
+++ b/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
@@ -155,6 +155,7 @@
     <Compile Include="StreamExtensionMethodTests.cs" />
     <Compile Include="StringDecoderTests.cs" />
     <Compile Include="ViewModels\LogWindowViewModelTests.cs" />
+    <Compile Include="ViewModels\SagaWindowViewModelTests.cs" />
     <Compile Include="XamlIconsTests.cs" />
     <Compile Include="XmlDecoderTests.cs" />
     <Compile Include="XmlViewerViewModelTests.cs" />

--- a/src/ServiceInsight.Tests/ViewModels/SagaWindowViewModelTests.cs
+++ b/src/ServiceInsight.Tests/ViewModels/SagaWindowViewModelTests.cs
@@ -1,0 +1,54 @@
+﻿namespace ServiceInsight.Tests.ViewModels
+{
+    using System;
+    using System.Collections.Generic;
+    using Caliburn.Micro;
+    using NSubstitute;
+    using NUnit.Framework;
+    using ServiceInsight.Framework;
+    using ServiceInsight.Framework.Events;
+    using ServiceInsight.Framework.UI.ScreenManager;
+    using ServiceInsight.MessageList;
+    using ServiceInsight.Models;
+    using ServiceInsight.Saga;
+    using ServiceInsight.ServiceControl;
+
+    [TestFixture]
+    public class SagaWindowViewModelTests
+    {
+        private SagaWindowViewModel viewModel;
+        private MessageSelectionContext messageSelectionContext;
+        private IServiceControl serviceControl;
+
+        [SetUp]
+        public void TestInitialize()
+        {
+            var eventAggregator = Substitute.For<IEventAggregator>();
+            var workNotifier = Substitute.For<IWorkNotifier>();
+            var clipboard = Substitute.For<IClipboard>();
+            var windowManager = Substitute.For<IWindowManagerEx>();
+
+            serviceControl = Substitute.For<IServiceControl>();
+            messageSelectionContext = new MessageSelectionContext(eventAggregator);
+            viewModel = new SagaWindowViewModel(eventAggregator, workNotifier, serviceControl, clipboard, windowManager, messageSelectionContext);
+        }
+
+        [Test]
+        public void When_initiating_message_can_not_be_found_doesnot_throw()
+        {
+            var sagaId = Guid.NewGuid();
+            var timeouts = new List<SagaTimeoutMessage> { new SagaTimeoutMessage { DeliverAt = DateTime.Now, Timeout = TimeSpan.FromMinutes(1) } };
+            var update = new SagaUpdate { InitiatingMessage = null, OutgoingMessages = timeouts };
+
+            var sagaChanges = new List<SagaUpdate> { update };
+            var sagaList = new List<SagaInfo> { new SagaInfo { SagaId = sagaId } };
+            var sagaData = new SagaData { Changes = sagaChanges };
+
+            messageSelectionContext.SelectedMessage = new StoredMessage { InvokedSagas = sagaList };
+            serviceControl.GetSagaById(Arg.Is(sagaId)).Returns(sagaData);
+            var selectedMessageChanged = new SelectedMessageChanged();
+
+            Assert.DoesNotThrow(() => viewModel.Handle(selectedMessageChanged));
+        }
+    }
+}

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -219,7 +219,7 @@
                 foreach (var timeout in sagaData.Changes.SelectMany(update => update.TimeoutMessages))
                 {
                     timeout.HasBeenProcessed =
-                        sagaData.Changes.Any(update => update.InitiatingMessage.MessageId == timeout.MessageId);
+                        sagaData.Changes.Any(update => update.InitiatingMessage?.MessageId == timeout.MessageId);
                 }
             }
 


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceInsight/issues/738

Doesn't assume that the InitiatingMessage object will exist. This object doesn't exist in the case where a saga has > 200 state changes where we inject a `missing_data` response to indicate that we're truncating the results.