### PR TITLE
Always show browse button

### DIFF
--- a/src/ServiceInsight/Shell/LicenseRegistrationView.xaml
+++ b/src/ServiceInsight/Shell/LicenseRegistrationView.xaml
@@ -118,10 +118,7 @@
                     Height="24"
                     Margin="{StaticResource ButtonMargin}"
                     Content="Browse..."
-                    Style="{StaticResource FlatButton}"
-                    Visibility="{Binding HasTrialLicense,
-                                         Converter={StaticResource BoolToVisibilityConverter}}" />
-
+                    Style="{StaticResource FlatButton}" />
         </StackPanel>
     </Grid>
 </dxc:DXWindow>


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceInsight/issues/760

Disables the visibility check so that users can _always_ browse to a new license regardless of their license version.

The `HasTrialLicense` property on the viewmodel is used in other properties so needs to remain.