### PR TITLE
Use a code default instead of config file

### DIFF
--- a/src/ServiceInsight/Framework/Settings/ApplicationConfiguration.cs
+++ b/src/ServiceInsight/Framework/Settings/ApplicationConfiguration.cs
@@ -16,11 +16,11 @@
         {
             try
             {
-                return Convert.ToBoolean(ConfigurationManager.AppSettings["SkipCertificateValidation"]);
+                return Convert.ToBoolean(ConfigurationManager.AppSettings["SkipCertificateValidation"] ?? "false");
             }
             catch (Exception ex)
             {
-                throw new ConfigurationErrorsException("Application setting 'SkipCertificateValidation' is either missing or cannot be converted to type Boolean.", ex);
+                throw new ConfigurationErrorsException("Application setting 'SkipCertificateValidation' cannot be converted to type Boolean.", ex);
             }
         }
     }


### PR DESCRIPTION
It seems that when upgrading the config file is not replaced, so we could be in a situation where users upgrade but don't have the default `SkipCertificateValidation` entry

Connects to #756