### PR TITLE
Install Microsoft.SDK.Expression.Blend instead of relying on installed expression blend SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,5 @@ If using Visual Studio 2017, ensure that you have installed:
 
 - Workloads
   - .NET desktop development
-- Individual components
-  - Blend for Visual Studio SDK for .NET
 
 You can check whether the prerequisites have been installed by running the Visual Studio Installer and clicking "Modify".
-
-### Troubleshooting
-
-The following compilation error in Visual Studio 2017 indicates that *Blend for Visual Studio SDK for .NET* has not been installed. See ["prerequisites"](#prerequisites).
-
-> Could not resolve this reference. Could not locate the assembly "System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL". Check to make sure the assembly exists on disk. If this reference is required by your code, you may get compilation errors.

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -150,6 +150,27 @@
       <HintPath>..\packages\AvalonEdit.5.0.3\lib\Net40\ICSharpCode.AvalonEdit.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Expression.Controls, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.Expression.Controls.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Expression.Drawing, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.Expression.Drawing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Expression.Effects, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.Expression.Effects.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Expression.Interactions, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.Expression.Interactions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Expression.Prototyping.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.Expression.Prototyping.Interactivity.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Expression.Prototyping.SketchControls, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.Expression.Prototyping.SketchControls.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SDK.Expression.Blend, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\Microsoft.SDK.Expression.Blend.dll</HintPath>
+    </Reference>
     <Reference Include="Mindscape.Raygun4Net">
       <HintPath>..\packages\Mindscape.Raygun4Net.5.0.0\lib\net40\Mindscape.Raygun4Net.dll</HintPath>
     </Reference>
@@ -217,7 +238,9 @@
     <Reference Include="System.Security" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SDK.Expression.Blend.1.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />

--- a/src/ServiceInsight/packages.config
+++ b/src/ServiceInsight/packages.config
@@ -12,6 +12,7 @@
   <package id="GitVersionTask" version="4.0.0-beta0012" targetFramework="net45" developmentDependency="true" />
   <package id="gong-wpf-dragdrop" version="0.1.4.1" targetFramework="net45" />
   <package id="Humanizer" version="1.34.0" targetFramework="net45" />
+  <package id="Microsoft.SDK.Expression.Blend" version="1.0.0" targetFramework="net45" />
   <package id="Mindscape.Raygun4Net" version="5.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="ObservablePropertyChanged" version="0.1.3" targetFramework="net45" developmentDependency="true" />


### PR DESCRIPTION
Tried to follow the build instructions explained in https://github.com/Particular/ServiceInsight#prerequisites but I could install Expression Blend SDK over the VS installer. I used 15.4.5.0 of VS.

But there seems to be a nuget package for the expression blend SDK. How about we use that one?