### PR TITLE
CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be the default owners for everything in the repo.
+*      @Particular/serviceinsight-maintainers


### PR DESCRIPTION
Some repos do have a [codeowners ](https://help.github.com/articles/about-codeowners/)file some don't. I just figured it might be handy as well since it automatically adds the group as a reviewer to PR.