### PR TITLE
Forward InstanceId to service control

### DIFF
--- a/src/ServiceInsight.Tests/Framework/Commands/RetryMessageCommandTests.cs
+++ b/src/ServiceInsight.Tests/Framework/Commands/RetryMessageCommandTests.cs
@@ -1,0 +1,44 @@
+﻿namespace ServiceInsight.Tests.Framework.Commands
+{
+    using Caliburn.Micro;
+    using NSubstitute;
+    using NUnit.Framework;
+    using ServiceInsight.Framework;
+    using ServiceInsight.Framework.Commands;
+    using ServiceInsight.Models;
+    using ServiceInsight.ServiceControl;
+
+    [TestFixture]
+    public class RetryMessageCommandTests
+    {
+        IEventAggregator eventAggregator;
+        IWorkNotifier workNotifier;
+        IServiceControl serviceControl;
+        RetryMessageCommand command;
+
+        [SetUp]
+        public void TestInitialize()
+        {
+            eventAggregator = Substitute.For<IEventAggregator>();
+            workNotifier = Substitute.For<IWorkNotifier>();
+            serviceControl = Substitute.For<IServiceControl>();
+            command = new RetryMessageCommand(eventAggregator, workNotifier, serviceControl);
+        }
+
+        [Test]
+        public void Should_use_instance_id_if_present()
+        {
+            command.Execute(new StoredMessage { InstanceId = "instanceId", Id = "messageId" });
+
+            serviceControl.Received().RetryMessage("messageId", "instanceId");
+        }
+
+        [Test]
+        public void Should_pass_null_instance_id()
+        {
+            command.Execute(new StoredMessage { Id = "messageId" });
+
+            serviceControl.Received().RetryMessage("messageId", null);
+        }
+    }
+}

--- a/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
+++ b/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="ConversationsData\PayLoad.cs" />
     <Compile Include="ConversationsData\SequenceDiagramModelCreatorTestsFromJson.cs" />
     <Compile Include="Framework\Attachments.cs" />
+    <Compile Include="Framework\Commands\RetryMessageCommandTests.cs" />
     <Compile Include="Framework\WorkNotiferTests.cs" />
     <Compile Include="Helpers\BinaryObjectCloner.cs" />
     <Compile Include="JsonViewerTests.cs" />

--- a/src/ServiceInsight/Framework/Commands/RetryMessageCommand.cs
+++ b/src/ServiceInsight/Framework/Commands/RetryMessageCommand.cs
@@ -41,7 +41,7 @@ namespace ServiceInsight.Framework.Commands
 
             using (workNotifier.NotifyOfWork($"Retrying to send selected error message {message.SendingEndpoint}"))
             {
-                serviceControl.RetryMessage(message.Id);
+                serviceControl.RetryMessage(message.Id, message.InstanceId);
                 eventAggregator.PublishOnUIThread(new RetryMessage { Id = message.Id });
             }
 

--- a/src/ServiceInsight/Models/StoredMessage.cs
+++ b/src/ServiceInsight/Models/StoredMessage.cs
@@ -37,6 +37,8 @@
 
         public string MessageId { get; set; }
 
+        public string InstanceId { get; set; }
+
         public List<StoredMessageHeader> Headers
         {
             get;

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -78,9 +78,11 @@
             return header == null ? null : header.Value.ToString();
         }
 
-        public void RetryMessage(string messageId)
+        public void RetryMessage(string messageId, string instanceId)
         {
-            var url = string.Format(RetryEndpoint, messageId);
+            var url = instanceId != null ?
+                string.Format(RetryEndpoint + "?instance_id={1}", messageId, instanceId) :
+                string.Format(RetryEndpoint, messageId);
             var request = new RestRequestWithCache(url, Method.POST);
             Execute(request, _ => true);
         }

--- a/src/ServiceInsight/ServiceControl/IServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/IServiceControl.cs
@@ -11,7 +11,7 @@ namespace ServiceInsight.ServiceControl
 
         string GetVersion();
 
-        void RetryMessage(string messageId);
+        void RetryMessage(string messageId, string instanceId);
 
         Uri CreateServiceInsightUri(StoredMessage message);
 


### PR DESCRIPTION
<!-- Connects to https://github.com/Particular/PlatformDevelopment/issues/1650 -->

In the multi-instance mode, the retry command in ServiceControl master needs to be sent either to the local instance or one of the remotes in case the remote did handle the error. 

Service Control newer versions of Service Control will return the instance id that can be passed back to ServiceControl. Based on the configured slave instances it then figures out to which instance it needs to send the message to. If the parameter is not present it always sends it to itself