### PR TITLE
Prefer KnownEndpointsUrl, to EndpointsUrl, to local default

### DIFF
--- a/src/ServiceInsight/Models/Endpoint.cs
+++ b/src/ServiceInsight/Models/Endpoint.cs
@@ -2,23 +2,31 @@
 {
     public class Endpoint
     {
-        string host;
-
-        public string Name { get; set; }
+        public string Name
+        {
+            get => EndpointDetails.Name;
+            set => EndpointDetails.Name = value;
+        }
 
         public string Host
         {
-            get { return host ?? HostDisplayName; }
-            set { host = value; }
+            get => EndpointDetails.Host ?? HostDisplayName;
+            set => EndpointDetails.Host = value;
         }
 
-        public string HostId { get; set; }
+        public string HostId
+        {
+            get => EndpointDetails.HostId;
+            set => EndpointDetails.HostId = value;
+        }
 
         public string HostDisplayName { get; set; }
 
-        public string Address => string.Format("{0}{1}", Name, AtMachine());
+        public string Address => $"{Name}{AtMachine()}";
 
-        string AtMachine() => string.IsNullOrEmpty(Host) ? string.Empty : string.Format("@{0}", Host);
+        public EndpointDetails EndpointDetails { get; set; } = new EndpointDetails();
+
+        string AtMachine() => string.IsNullOrEmpty(Host) ? string.Empty : $"@{Host}";
 
         protected bool Equals(Endpoint other) => other != null && string.Equals(Address, other.Address);
 
@@ -49,5 +57,14 @@
         public static bool operator !=(Endpoint left, Endpoint right) => !Equals(left, right);
 
         public override string ToString() => Address;
+    }
+
+    public class EndpointDetails
+    {
+        public string Name { get; set; }
+
+        public string HostId { get; set; }
+
+        public string Host { get; set; }
     }
 }

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -148,8 +148,8 @@ namespace ServiceInsight.ServiceControl
             endpointsUrl = endpointsUrl.Replace(connection.Url, string.Empty);
 
             var request = new RestRequestWithCache(endpointsUrl, RestRequestWithCache.CacheStyle.IfNotModified);
-            var messages = await GetModel<List<Endpoint>>(request).ConfigureAwait(false);
-            return messages ?? new List<Endpoint>();
+            var endpoints = await GetModel<List<Endpoint>>(request).ConfigureAwait(false);
+            return endpoints ?? new List<Endpoint>();
         }
 
         public async Task<IEnumerable<KeyValuePair<string, string>>> GetMessageData(SagaMessage message)

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceInsight.ServiceControl
+namespace ServiceInsight.ServiceControl
 {
     using System;
     using System.Collections.Generic;
@@ -33,7 +33,7 @@
         static byte[] byteOrderMarkUtf8 = Encoding.UTF8.GetPreamble();
 
         const string ConversationEndpoint = "conversations/{0}";
-        const string EndpointsEndpoint = "endpoints";
+        const string DefaultEndpointsEndpoint = "endpoints";
         const string EndpointMessagesEndpoint = "endpoints/{0}/messages/";
         const string RetryEndpoint = "errors/{0}/retry";
         const string MessagesEndpoint = "messages/";
@@ -81,6 +81,13 @@
             var header = await Execute(request, restResponse => restResponse.Headers.SingleOrDefault(x => x.Name == ServiceControlHeaders.ParticularVersion)).ConfigureAwait(false);
 
             return header == null ? null : header.Value.ToString();
+        }
+
+        Task<ServiceControlRootUrls> GetRootUrls()
+        {
+            var request = new RestRequestWithCache("/", RestRequestWithCache.CacheStyle.Immutable);
+
+            return GetModel<ServiceControlRootUrls>(request);
         }
 
         public Task RetryMessage(string messageId, string instanceId)
@@ -135,9 +142,13 @@
 
         public async Task<IEnumerable<Endpoint>> GetEndpoints()
         {
-            var request = new RestRequestWithCache(EndpointsEndpoint, RestRequestWithCache.CacheStyle.IfNotModified);
-            var messages = await GetModel<List<Endpoint>>(request).ConfigureAwait(false);
+            var rootUrls = await GetRootUrls().ConfigureAwait(false);
 
+            var endpointsUrl = rootUrls?.KnownEndpointsUrl ?? rootUrls?.EndpointsUrl ?? DefaultEndpointsEndpoint;
+            endpointsUrl = endpointsUrl.Replace(connection.Url, string.Empty);
+
+            var request = new RestRequestWithCache(endpointsUrl, RestRequestWithCache.CacheStyle.IfNotModified);
+            var messages = await GetModel<List<Endpoint>>(request).ConfigureAwait(false);
             return messages ?? new List<Endpoint>();
         }
 

--- a/src/ServiceInsight/ServiceControl/ServiceControlRootUrls.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlRootUrls.cs
@@ -1,0 +1,31 @@
+﻿namespace ServiceInsight.ServiceControl
+{
+    class ServiceControlRootUrls
+    {
+        public string Description { get; set; }
+
+        public string EndpointsErrorUrl { get; set; }
+
+        public string KnownEndpointsUrl { get; set; }
+
+        public string EndpointsMessageSearchUrl { get; set; }
+
+        public string EndpointsMessagesUrl { get; set; }
+
+        public string EndpointsUrl { get; set; }
+
+        public string ErrorsUrl { get; set; }
+
+        public string Configuration { get; set; }
+
+        public string MessageSearchUrl { get; set; }
+
+        public string LicenseStatus { get; set; }
+
+        public string LicenseDetails { get; set; }
+
+        public string Name { get; set; }
+
+        public string SagasUrl { get; set; }
+    }
+}

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -357,6 +357,7 @@
     <Compile Include="SequenceDiagram\ModelCreator.cs" />
     <Compile Include="ServiceControl\RestRequestWithCache.cs" />
     <Compile Include="ServiceControl\ServiceControlConnectionChanged.cs" />
+    <Compile Include="ServiceControl\ServiceControlRootUrls.cs" />
     <Compile Include="Settings\MessageListSettings.cs" />
     <Compile Include="Settings\SequenceDiagramSettings.cs" />
     <Compile Include="Shell\IPersistPartLayout.cs" />


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceInsight/issues/774

We have introduced a distinct API call to return the known endpoints from ServiceControl which is the, now, more correct call for ServiceInsight to make.

The change is intended to be backwards compatible, falling back to the "endpoints" const string when no other service is reported by ServiceControl for SI to use.