### PR TITLE
Set current page to one instead of zero

### DIFF
--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -275,7 +275,7 @@
                     pageSize = int.Parse(pageSizeText);
                 }
 
-                var currentPage = 0;
+                var currentPage = 1;
                 var page = requestQueryParameters["page"];
                 if (page != null)
                 {


### PR DESCRIPTION
Fixes weird behavior introduced by refactoring according to this comment 

https://github.com/Particular/ServiceInsight/pull/737#discussion_r164502253

### Before

150 msgs

Start

![image](https://user-images.githubusercontent.com/174258/35725536-f7f0a2fe-0801-11e8-8320-541a7d93f317.png)

click next

![image](https://user-images.githubusercontent.com/174258/35725554-07effea2-0802-11e8-93b7-69ceb26a4805.png)

indicates page 2

go back

![image](https://user-images.githubusercontent.com/174258/35725569-110428f6-0802-11e8-8740-46df6eaed1fe.png)

indicates page 1

### After

Right start with page 1

![image](https://user-images.githubusercontent.com/174258/35725588-2110e0d6-0802-11e8-8217-38ab9f65beea.png)

Empty result set is still page 0

![image](https://user-images.githubusercontent.com/174258/35725601-2eb6ae64-0802-11e8-827d-fb686a81e860.png)


Connects to #774.