### PR TITLE
Async Handling of ServiceControl communication

### DIFF
--- a/src/ServiceInsight.Tests/MessageBodyViewModelTests.cs
+++ b/src/ServiceInsight.Tests/MessageBodyViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceInsight.Tests
 {
     using System;
+    using System.Threading.Tasks;
     using Caliburn.Micro;
     using NSubstitute;
     using NUnit.Framework;
@@ -41,64 +42,64 @@
         }
 
         [Test]
-        public void Should_load_body_content_when_body_tab_is_already_selected()
+        public async Task Should_load_body_content_when_body_tab_is_already_selected()
         {
             const string uri = "http://localhost:3333/api/somemessageid/body";
 
             var messageBody = messageBodyFunc();
 
-            messageBody.Handle(new BodyTabSelectionChanged(true));
+            await messageBody.Handle(new BodyTabSelectionChanged(true));
 
             selection.SelectedMessage = new StoredMessage { BodyUrl = uri };
 
-            messageBody.Handle(new SelectedMessageChanged());
+            await messageBody.Handle(new SelectedMessageChanged());
 
-            serviceControl.Received(1).LoadBody(selection.SelectedMessage);
+            await serviceControl.Received(1).LoadBody(selection.SelectedMessage);
         }
 
         [Test]
-        public void Should_load_body_content_when_body_tab_is_focused()
+        public async Task Should_load_body_content_when_body_tab_is_focused()
         {
             const string uri = "http://localhost:3333/api/somemessageid/body";
 
             var messageBody = messageBodyFunc();
 
             selection.SelectedMessage = new StoredMessage { BodyUrl = uri };
-            messageBody.Handle(new SelectedMessageChanged());
+            await messageBody.Handle(new SelectedMessageChanged());
 
-            messageBody.Handle(new BodyTabSelectionChanged(true));
+            await messageBody.Handle(new BodyTabSelectionChanged(true));
 
-            serviceControl.Received(1).LoadBody(selection.SelectedMessage);
+            await serviceControl.Received(1).LoadBody(selection.SelectedMessage);
         }
 
         [Test]
-        public void Should_not_load_body_content_when_body_tab_is_not_focused()
+        public async Task Should_not_load_body_content_when_body_tab_is_not_focused()
         {
             const string uri = "http://localhost:3333/api/somemessageid/body";
 
             var messageBody = messageBodyFunc();
 
-            messageBody.Handle(new BodyTabSelectionChanged(false));
+            await messageBody.Handle(new BodyTabSelectionChanged(false));
 
             selection.SelectedMessage = new StoredMessage { BodyUrl = uri };
 
-            messageBody.Handle(new SelectedMessageChanged());
+            await messageBody.Handle(new SelectedMessageChanged());
 
-            serviceControl.Received(0).LoadBody(selection.SelectedMessage);
+            await serviceControl.Received(0).LoadBody(selection.SelectedMessage);
         }
 
         [Test]
-        public void Should_not_load_body_content_when_selected_message_has_no_body_url()
+        public async Task Should_not_load_body_content_when_selected_message_has_no_body_url()
         {
             var messageBody = messageBodyFunc();
 
-            messageBody.Handle(new BodyTabSelectionChanged(true));
+            await messageBody.Handle(new BodyTabSelectionChanged(true));
 
             selection.SelectedMessage = new StoredMessage { BodyUrl = null };
 
-            messageBody.Handle(new SelectedMessageChanged());
+            await messageBody.Handle(new SelectedMessageChanged());
 
-            serviceControl.Received(0).LoadBody(selection.SelectedMessage);
+            await serviceControl.Received(0).LoadBody(selection.SelectedMessage);
         }
     }
 }

--- a/src/ServiceInsight.Tests/MessageListViewModelTests.cs
+++ b/src/ServiceInsight.Tests/MessageListViewModelTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Caliburn.Micro;
     using NSubstitute;
     using NUnit.Framework;
@@ -48,7 +49,7 @@
         }
 
         [Test]
-        public void Should_load_the_messages_from_the_endpoint()
+        public async Task Should_load_the_messages_from_the_endpoint()
         {
             var endpoint = new Endpoint { Host = "localhost", Name = "Service" };
             serviceControl.GetAuditMessages(Arg.Is(endpoint), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>())
@@ -65,7 +66,7 @@
 
             var messageList = messageListFunc();
 
-            messageList.Handle(new SelectedExplorerItemChanged(new AuditEndpointExplorerItem(endpoint)));
+            await messageList.Handle(new SelectedExplorerItemChanged(new AuditEndpointExplorerItem(endpoint)));
 
             messageList.Rows.Count.ShouldBe(2);
             searchBar.IsVisible.ShouldBe(true);

--- a/src/ServiceInsight.Tests/SearchViewModelTests.cs
+++ b/src/ServiceInsight.Tests/SearchViewModelTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceInsight.Tests
 {
     using System;
+    using System.Windows.Threading;
     using NSubstitute;
     using NUnit.Framework;
     using ServiceInsight.Explorer.EndpointExplorer;
@@ -21,11 +22,15 @@
             var argParser = Substitute.For<CommandLineArgParser>();
             var settingProvider = Substitute.For<ISettingsProvider>();
 
+            // ReSharper disable once UnusedVariable
+            // required for async command
+            var dispatcher = Dispatcher.CurrentDispatcher;
             viewModel = new SearchBarViewModel(argParser, settingProvider);
         }
 
         public void Dispose()
         {
+            Dispatcher.ExitAllFrames();
             viewModel.Dispose();
         }
 

--- a/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
+++ b/src/ServiceInsight.Tests/ServiceInsight.Tests.csproj
@@ -86,9 +86,8 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RestSharp.105.0.1\lib\net4\RestSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=1.4.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/ServiceInsight.Tests/ViewModels/SagaWindowViewModelTests.cs
+++ b/src/ServiceInsight.Tests/ViewModels/SagaWindowViewModelTests.cs
@@ -48,7 +48,7 @@
             serviceControl.GetSagaById(Arg.Is(sagaId)).Returns(sagaData);
             var selectedMessageChanged = new SelectedMessageChanged();
 
-            Assert.DoesNotThrow(() => viewModel.Handle(selectedMessageChanged));
+            Assert.DoesNotThrowAsync(() => viewModel.Handle(selectedMessageChanged));
         }
     }
 }

--- a/src/ServiceInsight.Tests/packages.config
+++ b/src/ServiceInsight.Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net45" />
   <package id="ObservablePropertyChanged" version="0.1.3" targetFramework="net452" developmentDependency="true" />
-  <package id="RestSharp" version="105.0.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />

--- a/src/ServiceInsight/Framework/Command.cs
+++ b/src/ServiceInsight/Framework/Command.cs
@@ -3,22 +3,35 @@
     using System;
     using System.ComponentModel;
     using System.Reactive.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using Commands;
     using ExtensionMethods;
 
     public static class Command
     {
+        public static ICommand CreateAsync(Func<Task> executeAction, IObservable<bool> canExecuteObservable) =>
+            new AsyncObservableCommand(canExecuteObservable, _ => executeAction());
+
         public static ICommand Create(Action executeAction, IObservable<bool> canExecuteObservable) =>
             new ObservableCommand(canExecuteObservable, _ => executeAction());
 
         public static ICommand Create<TPropertyChanged>(TPropertyChanged propertyChanged, Action executeAction, Func<TPropertyChanged, bool> canExecuteSelector) where TPropertyChanged : INotifyPropertyChanged =>
             Create(executeAction, propertyChanged.ChangedProperty().Select(_ => canExecuteSelector(propertyChanged)));
 
+        public static ICommand CreateAsync<TPropertyChanged>(TPropertyChanged propertyChanged, Func<Task> executeAction, Func<TPropertyChanged, bool> canExecuteSelector) where TPropertyChanged : INotifyPropertyChanged =>
+            CreateAsync(executeAction, propertyChanged.ChangedProperty().Select(_ => canExecuteSelector(propertyChanged)));
+
         public static ICommand Create(Action executeAction) =>
             Create(_ => executeAction());
 
+        public static ICommand CreateAsync(Func<Task> executeAction) =>
+            CreateAsync(_ => executeAction());
+
         public static ICommand Create(Action<object> executeAction) =>
             new DelegateCommand(executeAction);
+
+        public static ICommand CreateAsync(Func<object, Task> executeAction) =>
+            new AsyncDelegateCommand(executeAction);
     }
 }

--- a/src/ServiceInsight/Framework/Commands/AsyncDelegateCommand.cs
+++ b/src/ServiceInsight/Framework/Commands/AsyncDelegateCommand.cs
@@ -1,0 +1,17 @@
+namespace ServiceInsight.Framework.Commands
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class AsyncDelegateCommand : BaseCommand
+    {
+        Func<object, Task> execute;
+
+        public AsyncDelegateCommand(Func<object, Task> execute)
+        {
+            this.execute = execute;
+        }
+
+        public override async void Execute(object parameter) => await execute(parameter);
+    }
+}

--- a/src/ServiceInsight/Framework/Commands/AsyncObservableCommand.cs
+++ b/src/ServiceInsight/Framework/Commands/AsyncObservableCommand.cs
@@ -1,0 +1,57 @@
+namespace ServiceInsight.Framework.Commands
+{
+    using System;
+    using System.Reactive.Disposables;
+    using System.Reactive.Linq;
+    using System.Threading.Tasks;
+    using System.Windows.Input;
+
+    class AsyncObservableCommand : ICommand
+    {
+        private Func<object, Task> action;
+        private bool latest;
+        private bool isExecuting;
+
+        public AsyncObservableCommand(IObservable<bool> canExecuteObservable, Func<object, Task> action)
+        {
+            this.action = action;
+
+            canExecuteObservable
+                .ObserveOnDispatcher()
+                .Subscribe(b =>
+                {
+                    latest = b;
+                    RaiseCanExecuteChanged();
+                });
+        }
+
+        public event EventHandler CanExecuteChanged;
+
+        public bool CanExecute(object parameter) => !isExecuting && latest;
+
+        public async void Execute(object parameter)
+        {
+            using (StartExecuting())
+            {
+                await action(parameter);
+            }
+        }
+
+        private void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        private IDisposable StartExecuting()
+        {
+            isExecuting = true;
+            RaiseCanExecuteChanged();
+
+            return Disposable.Create(() =>
+            {
+                isExecuting = false;
+                RaiseCanExecuteChanged();
+            });
+        }
+    }
+}

--- a/src/ServiceInsight/Framework/Commands/RetryMessageCommand.cs
+++ b/src/ServiceInsight/Framework/Commands/RetryMessageCommand.cs
@@ -31,7 +31,7 @@ namespace ServiceInsight.Framework.Commands
                    message.Status == MessageStatus.ArchivedFailure;
         }
 
-        public override void Execute(object parameter)
+        public override async void Execute(object parameter)
         {
             var message = parameter as StoredMessage;
             if (message == null)
@@ -41,7 +41,7 @@ namespace ServiceInsight.Framework.Commands
 
             using (workNotifier.NotifyOfWork($"Retrying to send selected error message {message.SendingEndpoint}"))
             {
-                serviceControl.RetryMessage(message.Id, message.InstanceId);
+                await serviceControl.RetryMessage(message.Id, message.InstanceId);
                 eventAggregator.PublishOnUIThread(new RetryMessage { Id = message.Id });
             }
 

--- a/src/ServiceInsight/Framework/Commands/SearchByMessageIDCommand.cs
+++ b/src/ServiceInsight/Framework/Commands/SearchByMessageIDCommand.cs
@@ -22,7 +22,7 @@ namespace ServiceInsight.Framework.Commands
             return message != null;
         }
 
-        public override void Execute(object parameter)
+        public override async void Execute(object parameter)
         {
             var message = parameter as StoredMessage;
             if (message == null)
@@ -30,7 +30,7 @@ namespace ServiceInsight.Framework.Commands
                 return;
             }
 
-            searchBar.Search(performSearch: true, searchQuery: message.MessageId);
+            await searchBar.Search(performSearch: true, searchQuery: message.MessageId);
             eventAggregator.PublishOnUIThread(new RequestSelectingEndpoint(message.ReceivingEndpoint));
         }
     }

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -4,6 +4,7 @@
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using Autofac;
     using Caliburn.Micro;
@@ -19,7 +20,7 @@
     using Settings;
 
     public class MessageFlowViewModel : Screen,
-        IHandle<SelectedMessageChanged>
+        IHandleWithTask<SelectedMessageChanged>
     {
         Func<ExceptionDetailViewModel> exceptionDetail;
         IServiceControl serviceControl;
@@ -136,7 +137,7 @@
 
         public ICommand RetryMessageCommand { get; }
 
-        public void Handle(SelectedMessageChanged @event)
+        public async Task Handle(SelectedMessageChanged @event)
         {
             var storedMessage = selection.SelectedMessage;
             if (storedMessage == null)
@@ -162,7 +163,7 @@
 
             loadedConversationId = conversationId;
 
-            var relatedMessagesTask = serviceControl.GetConversationById(conversationId);
+            var relatedMessagesTask = await serviceControl.GetConversationById(conversationId);
             var nodes = relatedMessagesTask
                 .Select(x => new MessageNode(this, x)
                 {

--- a/src/ServiceInsight/MessageList/MessageListView.xaml.cs
+++ b/src/ServiceInsight/MessageList/MessageListView.xaml.cs
@@ -3,6 +3,7 @@
     using System;
     using System.ComponentModel;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows;
     using System.Windows.Input;
     using DevExpress.Xpf.Core;
@@ -58,12 +59,12 @@
             e.Cancel = grid.ShowLoadingPanel;
         }
 
-        void SortData(ColumnBase column, ListSortDirection order)
+        async Task SortData(ColumnBase column, ListSortDirection order)
         {
             var orderBy = column.Tag as string;
             var ascending = order == ListSortDirection.Ascending;
 
-            Model.RefreshMessages(orderBy, ascending);
+            await Model.RefreshMessages(orderBy, ascending);
         }
 
         void Grid_OnCustomColumnDisplayText(object sender, CustomColumnDisplayTextEventArgs e)
@@ -78,7 +79,7 @@
             }
         }
 
-        void Grid_OnStartSorting(object sender, RoutedEventArgs e)
+        async void Grid_OnStartSorting(object sender, RoutedEventArgs e)
         {
             var grid = e.Source as GridControl;
 
@@ -96,7 +97,7 @@
 
             var column = grid.Columns.First(c => c.FieldName == sortInfo.FieldName);
 
-            SortData(column, sortInfo.SortOrder);
+            await SortData(column, sortInfo.SortOrder);
 
             e.Handled = true;
         }

--- a/src/ServiceInsight/MessageList/MessageListViewModel.cs
+++ b/src/ServiceInsight/MessageList/MessageListViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Reactive.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using Caliburn.Micro;
     using Comparers;
@@ -22,7 +23,7 @@
 
     public class MessageListViewModel : RxConductor<RxScreen>.Collection.AllActive,
         IWorkTracker,
-        IHandle<SelectedExplorerItemChanged>,
+        IHandleWithTask<SelectedExplorerItemChanged>,
         IHandle<WorkStarted>,
         IHandle<WorkFinished>,
         IHandle<AsyncOperationFailed>,
@@ -104,11 +105,11 @@
             clipboard.CopyTo(generalHeaderDisplay.HeaderContent);
         }
 
-        public void RefreshMessages(string link)
+        public async Task RefreshMessages(string link)
         {
             using (workNotifier.NotifyOfWork("Loading messages..."))
             {
-                var pagedResult = serviceControl.GetAuditMessages(link);
+                var pagedResult = await serviceControl.GetAuditMessages(link);
 
                 if (pagedResult == null)
                 {
@@ -122,31 +123,31 @@
             }
         }
 
-        public void RefreshMessages(string orderBy, bool ascending)
+        public async Task RefreshMessages(string orderBy, bool ascending)
         {
             lastSortColumn = orderBy;
             lastSortOrderAscending = ascending;
-            RefreshMessages();
+            await RefreshMessages();
         }
 
-        public void RefreshMessages()
+        public async Task RefreshMessages()
         {
             if (selectedExplorerItem is ServiceControlExplorerItem)
             {
-                RefreshMessages(null, SearchBar.SearchQuery);
+                await RefreshMessages(null, SearchBar.SearchQuery);
             }
 
             if (selectedExplorerItem is AuditEndpointExplorerItem endpointNode)
             {
-                RefreshMessages(endpointNode.Endpoint, SearchBar.SearchQuery);
+                await RefreshMessages(endpointNode.Endpoint, SearchBar.SearchQuery);
             }
         }
 
-        public void RefreshMessages(Endpoint endpoint, string searchQuery)
+        public async Task RefreshMessages(Endpoint endpoint, string searchQuery)
         {
             using (workNotifier.NotifyOfWork($"Loading {(endpoint == null ? "all" : endpoint.Address)} messages..."))
             {
-                var pagedResult = serviceControl.GetAuditMessages(endpoint, searchQuery, lastSortColumn, lastSortOrderAscending);
+                var pagedResult = await serviceControl.GetAuditMessages(endpoint, searchQuery, lastSortColumn, lastSortOrderAscending);
                 if (pagedResult == null)
                 {
                     return;
@@ -174,10 +175,10 @@
             }
         }
 
-        public void Handle(SelectedExplorerItemChanged @event)
+        public async Task Handle(SelectedExplorerItemChanged @event)
         {
             selectedExplorerItem = @event.SelectedExplorerItem;
-            RefreshMessages();
+            await RefreshMessages();
             SearchBar.NotifyPropertiesChanged();
         }
 

--- a/src/ServiceInsight/MessageViewers/MessageBodyViewModel.cs
+++ b/src/ServiceInsight/MessageViewers/MessageBodyViewModel.cs
@@ -1,6 +1,7 @@
 ﻿namespace ServiceInsight.MessageViewers
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Caliburn.Micro;
     using ExtensionMethods;
     using Framework;
@@ -12,8 +13,8 @@
     using XmlViewer;
 
     public class MessageBodyViewModel : Screen,
-        IHandle<SelectedMessageChanged>,
-        IHandle<BodyTabSelectionChanged>,
+        IHandleWithTask<SelectedMessageChanged>,
+        IHandleWithTask<BodyTabSelectionChanged>,
         IHandle<ServiceControlConnectionChanged>
     {
         readonly IServiceControl serviceControl;
@@ -85,10 +86,10 @@
 
         public bool NoContentHelpVisible => PresentationHint == PresentationHint.NoContent;
 
-        public void Handle(SelectedMessageChanged @event)
+        public async Task Handle(SelectedMessageChanged @event)
         {
             ClearMessageDisplays();
-            LoadMessageBody();
+            await LoadMessageBody();
 
             if (selection.SelectedMessage != null)
             {
@@ -113,12 +114,12 @@
             }
         }
 
-        public void Handle(BodyTabSelectionChanged @event)
+        public async Task Handle(BodyTabSelectionChanged @event)
         {
             ShouldLoadMessageBody = @event.IsSelected;
             if (ShouldLoadMessageBody)
             {
-                LoadMessageBody();
+                await LoadMessageBody();
             }
         }
 
@@ -135,7 +136,7 @@
             }
         }
 
-        void LoadMessageBody()
+        async Task LoadMessageBody()
         {
             if (selection.SelectedMessage == null || !ShouldLoadMessageBody || selection.SelectedMessage.BodyUrl.IsEmpty())
             {
@@ -144,7 +145,7 @@
 
             using (workNotifier.NotifyOfWork("Loading message body..."))
             {
-                serviceControl.LoadBody(selection.SelectedMessage);
+                await serviceControl.LoadBody(selection.SelectedMessage);
 
                 RefreshChildren();
             }

--- a/src/ServiceInsight/Models/CommandLineOptions.cs
+++ b/src/ServiceInsight/Models/CommandLineOptions.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Text.RegularExpressions;
-    using RestSharp.Contrib;
+    using RestSharp.Extensions.MonoHttp;
 
     public class CommandLineOptions
     {

--- a/src/ServiceInsight/Saga/SagaMessage.cs
+++ b/src/ServiceInsight/Saga/SagaMessage.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Caliburn.Micro;
     using Framework;
     using Models;
@@ -82,14 +83,14 @@
 
         public IEnumerable<SagaMessageDataItem> Data { get; private set; }
 
-        internal void RefreshData(IServiceControl serviceControl)
+        internal async Task RefreshData(IServiceControl serviceControl)
         {
             if (Data != null)
             {
                 return;
             }
 
-            Data = serviceControl.GetMessageData(this).Select(kvp => new SagaMessageDataItem { Key = kvp.Key, Value = kvp.Value }).ToList();
+            Data = (await serviceControl.GetMessageData(this)).Select(kvp => new SagaMessageDataItem { Key = kvp.Key, Value = kvp.Value }).ToList();
         }
     }
 

--- a/src/ServiceInsight/Search/SearchBarView.xaml.cs
+++ b/src/ServiceInsight/Search/SearchBarView.xaml.cs
@@ -9,11 +9,11 @@
             InitializeComponent();
         }
 
-        void OnSearchKeyDown(object sender, KeyEventArgs e)
+        async void OnSearchKeyDown(object sender, KeyEventArgs e)
         {
             if ((e.Key == Key.Return || e.Key == Key.Enter) && Model != null)
             {
-                Model.Search();
+                await Model.Search();
             }
         }
 

--- a/src/ServiceInsight/Search/SearchBarViewModel.cs
+++ b/src/ServiceInsight/Search/SearchBarViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using Caliburn.Micro;
     using Explorer.EndpointExplorer;
@@ -33,11 +34,11 @@
             this.commandLineArgParser = commandLineArgParser;
             this.settingProvider = settingProvider;
 
-            SearchCommand = Command.Create(this, Search, vm => vm.CanSearch);
-            CancelSearchCommand = Command.Create(this, CancelSearch, vm => vm.CanCancelSearch);
+            SearchCommand = Command.CreateAsync(this, Search, vm => vm.CanSearch);
+            CancelSearchCommand = Command.CreateAsync(this, CancelSearch, vm => vm.CanCancelSearch);
         }
 
-        protected override void OnActivate()
+        protected override async void OnActivate()
         {
             base.OnActivate();
 
@@ -45,35 +46,35 @@
 
             if (!string.IsNullOrEmpty(commandLineArgParser.ParsedOptions.SearchQuery))
             {
-                Search(commandLineArgParser.ParsedOptions.SearchQuery);
+                await Search(commandLineArgParser.ParsedOptions.SearchQuery);
             }
         }
 
-        public void GoToFirstPage()
+        public async Task GoToFirstPage()
         {
-            Parent.RefreshMessages(FirstLink);
+            await Parent.RefreshMessages(FirstLink);
         }
 
-        public void GoToPreviousPage()
+        public async Task GoToPreviousPage()
         {
-            Parent.RefreshMessages(PrevLink);
+            await Parent.RefreshMessages(PrevLink);
         }
 
-        public void GoToNextPage()
+        public async Task GoToNextPage()
         {
-            Parent.RefreshMessages(NextLink);
+            await Parent.RefreshMessages(NextLink);
         }
 
-        public void GoToLastPage()
+        public async Task GoToLastPage()
         {
-            Parent.RefreshMessages(LastLink);
+            await Parent.RefreshMessages(LastLink);
         }
 
         public ICommand SearchCommand { get; }
 
         public ICommand CancelSearchCommand { get; }
 
-        public void Search(string searchQuery, bool performSearch = true)
+        public async Task Search(string searchQuery, bool performSearch = true)
         {
             SearchQuery = searchQuery;
             SearchInProgress = !SearchQuery.IsEmpty();
@@ -82,22 +83,22 @@
 
             if (performSearch)
             {
-                Search();
+                await Search();
             }
         }
 
-        public void Search()
+        public async Task Search()
         {
             SearchInProgress = true;
             AddRecentSearchEntry(SearchQuery);
-            Parent.RefreshMessages(SelectedEndpoint, SearchQuery);
+            await Parent.RefreshMessages(SelectedEndpoint, SearchQuery);
         }
 
-        public void CancelSearch()
+        public async Task CancelSearch()
         {
             SearchQuery = null;
             SearchInProgress = false;
-            Parent.RefreshMessages(SelectedEndpoint, SearchQuery);
+            await Parent.RefreshMessages(SelectedEndpoint, SearchQuery);
         }
 
         public void SetupPaging(PagedResult<StoredMessage> pagedResult)
@@ -124,9 +125,9 @@
         }
 
         // Required for binding convention with CanRefreshResult
-        public void RefreshResult()
+        public async Task RefreshResult()
         {
-            Search();
+            await Search();
         }
 
         public bool CanGoToLastPage => LastLink != null && !WorkInProgress;

--- a/src/ServiceInsight/SequenceDiagram/SequenceDiagramViewModel.cs
+++ b/src/ServiceInsight/SequenceDiagram/SequenceDiagramViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using Anotar.Serilog;
     using Caliburn.Micro;
@@ -18,7 +19,7 @@
     using ServiceInsight.Settings;
 
     public class SequenceDiagramViewModel : Screen,
-        IHandle<SelectedMessageChanged>,
+        IHandleWithTask<SelectedMessageChanged>,
         IHandle<ScrollDiagramItemIntoView>,
         IMessageCommandContainer
     {
@@ -120,7 +121,7 @@
             DiagramLegend.DeactivateWith(this);
         }
 
-        public void Handle(SelectedMessageChanged message)
+        public async Task Handle(SelectedMessageChanged message)
         {
             try
             {
@@ -137,7 +138,7 @@
                     return;
                 }
 
-                var messages = serviceControl.GetConversationById(conversationId).ToList();
+                var messages = (await serviceControl.GetConversationById(conversationId)).ToList();
                 if (messages.Count == 0)
                 {
                     LogTo.Warning("No messages found for conversation id {0}", conversationId);

--- a/src/ServiceInsight/ServiceControl/IServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/IServiceControl.cs
@@ -2,32 +2,33 @@ namespace ServiceInsight.ServiceControl
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Models;
     using Saga;
 
     public interface IServiceControl
     {
-        bool IsAlive();
+        Task<bool> IsAlive();
 
-        string GetVersion();
+        Task<string> GetVersion();
 
-        void RetryMessage(string messageId, string instanceId);
+        Task RetryMessage(string messageId, string instanceId);
 
         Uri CreateServiceInsightUri(StoredMessage message);
 
-        SagaData GetSagaById(Guid sagaId);
+        Task<SagaData> GetSagaById(Guid sagaId);
 
-        PagedResult<StoredMessage> GetAuditMessages(Endpoint endpoint = null, string searchQuery = null, string orderBy = null, bool ascending = false);
+        Task<PagedResult<StoredMessage>> GetAuditMessages(Endpoint endpoint = null, string searchQuery = null, string orderBy = null, bool ascending = false);
 
-        PagedResult<StoredMessage> GetAuditMessages(string link);
+        Task<PagedResult<StoredMessage>> GetAuditMessages(string link);
 
-        IEnumerable<StoredMessage> GetConversationById(string conversationId);
+        Task<IEnumerable<StoredMessage>> GetConversationById(string conversationId);
 
-        IEnumerable<Endpoint> GetEndpoints();
+        Task<IEnumerable<Endpoint>> GetEndpoints();
 
-        IEnumerable<KeyValuePair<string, string>> GetMessageData(SagaMessage messageId);
+        Task<IEnumerable<KeyValuePair<string, string>>> GetMessageData(SagaMessage messageId);
 
-        void LoadBody(StoredMessage message);
+        Task LoadBody(StoredMessage message);
     }
 
     public class ServiceControlHeaders

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -201,8 +201,8 @@
       <HintPath>..\packages\PropertyChanged.Fody.1.50.3\lib\dotnet\PropertyChanged.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>..\packages\RestSharp.105.0.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
       <HintPath>..\packages\Serilog.1.4.204\lib\net45\Serilog.dll</HintPath>
@@ -284,6 +284,8 @@
     <Compile Include="ExtensionMethods\JObjectExtensions.cs" />
     <Compile Include="Framework\Behaviors\ComboBoxEditValuePatcherBehavior.cs" />
     <Compile Include="Framework\Behaviors\CommandParameterHelper.cs" />
+    <Compile Include="Framework\Commands\AsyncDelegateCommand.cs" />
+    <Compile Include="Framework\Commands\AsyncObservableCommand.cs" />
     <Compile Include="Framework\Commands\CloseWindowCommand.cs" />
     <Compile Include="Framework\Commands\DelegateCommand.cs" />
     <Compile Include="Framework\Commands\ObservableCommand.cs" />

--- a/src/ServiceInsight/Shell/AboutViewModel.cs
+++ b/src/ServiceInsight/Shell/AboutViewModel.cs
@@ -4,6 +4,7 @@ namespace ServiceInsight.Shell
     using System.ComponentModel;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using System.Windows.Input;
     using Caliburn.Micro;
     using ServiceInsight.ExtensionMethods;
@@ -74,12 +75,12 @@ namespace ServiceInsight.Shell
             Activated(this, new ActivationEventArgs());
         }
 
-        void OnActivate()
+        async void OnActivate()
         {
             ActivateLicense();
             LoadAppVersion();
             SetCopyrightText();
-            LoadVersions();
+            await LoadVersions();
         }
 
         void ActivateLicense()
@@ -115,7 +116,7 @@ namespace ServiceInsight.Shell
             CopyrightText = string.Format("Copyright 2013-{0} NServiceBus Ltd. All rights reserved.", DateTime.Now.Year);
         }
 
-        void LoadVersions()
+        async Task LoadVersions()
         {
             if (serviceControl == null)
             {
@@ -124,7 +125,7 @@ namespace ServiceInsight.Shell
 
             ServiceControlVersion = DetectingServiceControlVersion;
 
-            var version = serviceControl.GetVersion();
+            var version = await serviceControl.GetVersion();
             ServiceControlVersion = version ?? NotConnectedToServiceControl;
         }
     }

--- a/src/ServiceInsight/Shell/ServiceControlConnectionViewModel.cs
+++ b/src/ServiceInsight/Shell/ServiceControlConnectionViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Autofac;
     using Caliburn.Micro;
     using ServiceControl;
@@ -56,11 +57,11 @@
 
         public string Version { get; private set; }
 
-        public virtual void Accept()
+        public virtual async Task Accept()
         {
             StartWorkInProgress();
             ServiceUrl = ServiceUrl.Trim();
-            IsAddressValid = IsValidUrl(ServiceUrl);
+            IsAddressValid = await IsValidUrl(ServiceUrl);
             if (IsAddressValid)
             {
                 StoreConnectionAddress();
@@ -101,7 +102,7 @@
             settingsProvider.SaveSettings(appSettings);
         }
 
-        bool IsValidUrl(string serviceUrl)
+        async Task<bool> IsValidUrl(string serviceUrl)
         {
             if (serviceUrl.IsValidUrl())
             {
@@ -111,7 +112,7 @@
                     var service = scope.Resolve<IServiceControl>();
 
                     connection.ConnectTo(serviceUrl);
-                    Version = service.GetVersion();
+                    Version = await service.GetVersion();
 
                     return Version != null;
                 }

--- a/src/ServiceInsight/packages.config
+++ b/src/ServiceInsight/packages.config
@@ -19,7 +19,7 @@
   <package id="Particular.CodeRules" version="0.1.1" targetFramework="net45" developmentDependency="true" />
   <package id="Particular.Licensing.Sources" version="1.0.0-alpha0007" targetFramework="net45" />
   <package id="PropertyChanged.Fody" version="1.50.3" targetFramework="net45" developmentDependency="true" />
-  <package id="RestSharp" version="105.0.1" targetFramework="net45" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />


### PR DESCRIPTION
Connects to https://github.com/Particular/ServiceInsight/issues/774
Fixes #779 

- RestSharp upgrade is required. The version used on master throws webexceptions in the async mode


I've smoke tested it with one and multiple ServiceControl instances. The overall behavior is much smoother now even when the master SC is timing out. As a plus the loading screens are now finally visible again because the UI has time to actually render those :)

The video shows the behavior with a multi instance master where the slave is not available and timing out

[![ServiceInsight Async](https://img.youtube.com/vi/g7m2BBXkag0/0.jpg)](https://youtu.be/g7m2BBXkag0)

The video below shows the behavior with multi-instance when the slaves are available

[![ServiceInsight Async](https://img.youtube.com/vi/WFfeXsyVYsM/0.jpg)](https://youtu.be/WFfeXsyVYsM)

You'll see once how the sequence diagram collapses. I have that on my machine even with the current released version.