### PR TITLE
Add the ESC binding to dialogs only

### DIFF
--- a/src/ServiceInsight/Framework/UI/ScreenManager/WindowManagerEx.cs
+++ b/src/ServiceInsight/Framework/UI/ScreenManager/WindowManagerEx.cs
@@ -81,7 +81,10 @@
         {
             var window = base.CreateWindow(rootModel, isDialog, context, settings);
 
-            window.InputBindings.Add(new KeyBinding(new CloseWindowCommand(window), new KeyGesture(Key.Escape)));
+            if (isDialog)
+            {
+                window.InputBindings.Add(new KeyBinding(new CloseWindowCommand(window), new KeyGesture(Key.Escape)));
+            }
 
             return window;
         }


### PR DESCRIPTION
Fixes https://github.com/Particular/ServiceInsight/issues/784

This performs a check before adding the binding so that the ESC binding is only added to dialogs and not to the main window.