### PR TITLE
Exclude .dependabot/config.yml from repo sync

### DIFF
--- a/.reposync.yml
+++ b/.reposync.yml
@@ -2,3 +2,4 @@ exclusions:
 - src/Directory.Build.props
 - src/NServiceBus.snk
 - GitVersion.yml
+- .dependabot/config.yml


### PR DESCRIPTION
Related to https://github.com/Particular/RepoStandards/pull/22