### PR TITLE
remove redundant reposync exclusion

### DIFF
--- a/.reposync.yml
+++ b/.reposync.yml
@@ -1,3 +1,2 @@
 exclusions:
 - src/NServiceBus.snk
-- .dependabot/config.yml


### PR DESCRIPTION
was made redundant by https://github.com/Particular/ServiceInsight/pull/875