### PR TITLE
Use Particular.Packaging instead of GitVersionTask

### DIFF
--- a/src/ServiceInsight.Licensing/ServiceInsight.Licensing.csproj
+++ b/src/ServiceInsight.Licensing/ServiceInsight.Licensing.csproj
@@ -4,17 +4,20 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>library</OutputType>
     <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Particular.CodeRules" Version="0.4.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.4.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Anotar.Serilog.Fody" Version="5.1.3" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="3.4.0" PrivateAssets="All" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <Company>NServiceBus Ltd.</Company>
     <ApplicationIcon>ServiceInsight.ico</ApplicationIcon>
     <UseWpf>true</UseWpf>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -51,6 +52,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
     <PackageReference Include="ObservablePropertyChanged" Version="0.1.3" />
     <PackageReference Include="Particular.CodeRules" Version="0.4.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
     <PackageReference Include="RestSharp" Version="105.2.3" />
     <PackageReference Include="Rx-Core" Version="2.2.5" />
     <PackageReference Include="Rx-Interfaces" Version="2.2.5" />
@@ -68,7 +70,6 @@
     <PackageReference Include="Anotar.Serilog.Fody" Version="5.1.3" PrivateAssets="All" />
     <PackageReference Include="EmptyConstructor.Fody" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.2.0" PrivateAssets="All" />
-    <PackageReference Include="GitVersionTask" Version="5.5.0" PrivateAssets="All" />
     <PackageReference Include="PropertyChanged.Fody" Version="3.2.8" PrivateAssets="All" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.5.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="CreateInstaller" AfterTargets="Build" Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Connects to: https://github.com/Particular/ServiceInsight/issues/947

This aligns the repo with all the others to use Particular.Packaging instead of referencing GitVersionTask directly.

Notice that Particular.Packaging has also been added to the ServiceInsight.Licensing project even though it wasn't previously using GitVersionTask. This fixes the issue with none of the assemblies having a release date attribute.

The release date MSBuild target that comes from the Particular.Licensing.Sources package requires GitVersion to run so that it can use version numbers in the logic. Since the project didn't previously have GitVersonTask, that meant that the target was skipped.