### PR TITLE
Making a change to get a message body for audited messages

### DIFF
--- a/src/ServiceInsight/Saga/SagaMessage.cs
+++ b/src/ServiceInsight/Saga/SagaMessage.cs
@@ -20,6 +20,8 @@
     {
         public string MessageId { get; set; }
 
+        public string BodyUrl { get; set; }
+
         public bool IsPublished { get; set; }
 
         public MessageIntent Intent { get; set; }

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -98,7 +98,7 @@
                     var auditMessages = await ServiceControl.GetAuditMessages(searchQuery: Data.SagaId.ToString())
                         .ConfigureAwait(false);
                     messages.ForEach(a =>
-                        a.BodyUrl = auditMessages.Result.FirstOrDefault(x => x.MessageId == a.MessageId).BodyUrl);
+                        a.BodyUrl = auditMessages.Result.FirstOrDefault(x => x.MessageId == a.MessageId)?.BodyUrl);
                 }
 
                 foreach (var message in messages)

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -92,7 +92,8 @@
             if (ServiceControl != null)
             {
                 var messages = Data.Changes.Select(c => c.InitiatingMessage)
-                    .Union(Data.Changes.SelectMany(c => c.OutgoingMessages));
+                    .Union(Data.Changes.SelectMany(c => c.OutgoingMessages))
+                    .ToList();
                 if (messages.All(x => string.IsNullOrEmpty(x.BodyUrl)))
                 {
                     var auditMessages = await ServiceControl.GetAuditMessages(searchQuery: Data.SagaId.ToString())

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -93,7 +93,7 @@
             {
                 var messages = Data.Changes.Select(c => c.InitiatingMessage)
                     .Union(Data.Changes.SelectMany(c => c.OutgoingMessages));
-                if (!messages.Any(x => !string.IsNullOrEmpty(x.BodyUrl)))
+                if (messages.All(x => string.IsNullOrEmpty(x.BodyUrl)))
                 {
                     var auditMessages = await ServiceControl.GetAuditMessages(searchQuery: Data.SagaId.ToString())
                         .ConfigureAwait(false);

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -1,9 +1,8 @@
-﻿using ServiceInsight.Explorer;
-using ServiceInsight.ExtensionMethods;
-
-namespace ServiceInsight.Saga
+﻿namespace ServiceInsight.Saga
 {
     using System;
+    using Explorer;
+    using ExtensionMethods;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -52,7 +51,7 @@ namespace ServiceInsight.Saga
         }
 
         IServiceControl ServiceControl => selectedExplorerItem.GetServiceControlClient(clientRegistry);
-        
+
         public string InstallScriptText { get; } = "install-package NServiceBus.SagaAudit";
 
         public ICommand CopyCommand { get; }
@@ -92,14 +91,23 @@ namespace ServiceInsight.Saga
         {
             if (ServiceControl != null)
             {
-                foreach (var message in Data.Changes.Select(c => c.InitiatingMessage)
-                    .Union(Data.Changes.SelectMany(c => c.OutgoingMessages)))
+                var messages = Data.Changes.Select(c => c.InitiatingMessage)
+                    .Union(Data.Changes.SelectMany(c => c.OutgoingMessages));
+                if (!messages.Any(x => !string.IsNullOrEmpty(x.BodyUrl)))
+                {
+                    var auditMessages = await ServiceControl.GetAuditMessages(searchQuery: Data.SagaId.ToString())
+                        .ConfigureAwait(false);
+                    messages.ForEach(a =>
+                        a.BodyUrl = auditMessages.Result.FirstOrDefault(x => x.MessageId == a.MessageId).BodyUrl);
+                }
+
+                foreach (var message in messages)
                 {
                     await message.RefreshData(ServiceControl);
                 }
-            }
 
-            NotifyOfPropertyChange(nameof(Data));
+                NotifyOfPropertyChange(nameof(Data));
+            }
         }
 
         public async Task Handle(SelectedMessageChanged @event)
@@ -210,12 +218,12 @@ namespace ServiceInsight.Saga
         private async Task<SagaData> FetchOrderedSagaData(Guid sagaId)
         {
             var sagaData = default(SagaData);
-            
+
             if (ServiceControl != null)
             {
                 sagaData = await ServiceControl.GetSagaById(sagaId);
             }
-            
+
             if (sagaData?.Changes != null)
             {
                 sagaData.Changes = sagaData.Changes.OrderBy(x => x.StartTime)

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -188,7 +188,11 @@ namespace ServiceInsight.ServiceControl
 
         public async Task<IEnumerable<KeyValuePair<string, string>>> GetMessageData(SagaMessage message)
         {
-            var request = new RestRequestWithCache(string.Format(MessageBodyEndpoint, message.MessageId), message.Status == MessageStatus.Successful ? RestRequestWithCache.CacheStyle.Immutable : RestRequestWithCache.CacheStyle.IfNotModified);
+            var bodyUrl = message.BodyUrl ?? string.Format(MessageBodyEndpoint, message.MessageId);
+            var request = new RestRequestWithCache(bodyUrl,
+                message.Status == MessageStatus.Successful
+                    ? RestRequestWithCache.CacheStyle.IfNotModified
+                    : RestRequestWithCache.CacheStyle.IfNotModified);
 
             var body = await Execute(request, response => response.Content, truncateLargeLists: true).ConfigureAwait(false);
 
@@ -211,7 +215,7 @@ namespace ServiceInsight.ServiceControl
             }
 
             message.Body = await Execute(
-                request, 
+                request,
                 response =>
                 {
                     var presentationBody = new PresentationBody();
@@ -228,7 +232,7 @@ namespace ServiceInsight.ServiceControl
                     }
 
                     return presentationBody;
-                }, 
+                },
                 baseUrl).ConfigureAwait(false);
         }
 
@@ -295,7 +299,7 @@ namespace ServiceInsight.ServiceControl
         Task<PagedResult<T>> GetPagedResult<T>(RestRequestWithCache request, string url = null) where T : class, new()
         {
             var result = Execute<PagedResult<T>, List<T>>(
-                request, 
+                request,
                 response =>
                 {
                     string first = null, prev = null, next = null, last = null;
@@ -357,7 +361,7 @@ namespace ServiceInsight.ServiceControl
                         TotalCount = int.Parse(response.Headers.First(x => x.Name == ServiceControlHeaders.TotalCount).Value.ToString()),
                         PageSize = pageSize
                     };
-                }, 
+                },
                 url);
 
             return result;
@@ -541,7 +545,7 @@ where T : class, new() => Execute<T, T>(request, response => response.Data, trun
 
         private void RaiseConnectivityIssue(IRestResponse response)
         {
-           if (response?.ErrorException is WebException webException && 
+           if (response?.ErrorException is WebException webException &&
                webException.Status == WebExceptionStatus.ConnectFailure)
            {
                LogError(response);
@@ -630,7 +634,7 @@ where T : class, new() => Execute<T, T>(request, response => response.Data, trun
             foreach (var parameter in request.Parameters)
             {
                 LogTo.Debug(
-                    "Request Parameter: {Name} : {Value}", 
+                    "Request Parameter: {Name} : {Value}",
                     parameter.Name,
                     parameter.Value);
             }


### PR DESCRIPTION
Ok, this PR seems to solve the problem of bodies. I had to leave the MessageBodyEndpoint const as this works for error messages. I tested it for audits and errors and it seems to be ok. 