### PR TITLE
Push query down to SC access layer

### DIFF
--- a/src/ServiceInsight/Saga/SagaData.cs
+++ b/src/ServiceInsight/Saga/SagaData.cs
@@ -10,6 +10,11 @@
     {
         public List<SagaUpdate> Changes { get; set; }
 
+        public List<SagaMessage> RelatedMessages
+            => Changes.Select(x => x.InitiatingMessage)
+                .Union(Changes.SelectMany(x => x.OutgoingMessages))
+                .ToList();
+
         public Guid SagaId { get; set; }
 
         string sagaType;

--- a/src/ServiceInsight/Saga/SagaWindowViewModel.cs
+++ b/src/ServiceInsight/Saga/SagaWindowViewModel.cs
@@ -91,17 +91,7 @@
         {
             if (ServiceControl != null)
             {
-                var messages = Data.Changes.Select(c => c.InitiatingMessage)
-                    .Union(Data.Changes.SelectMany(c => c.OutgoingMessages));
-                if (messages.All(x => string.IsNullOrEmpty(x.BodyUrl)))
-                {
-                    var auditMessages = await ServiceControl.GetAuditMessages(searchQuery: Data.SagaId.ToString())
-                        .ConfigureAwait(false);
-                    messages.ForEach(a =>
-                        a.BodyUrl = auditMessages.Result.FirstOrDefault(x => x.MessageId == a.MessageId).BodyUrl);
-                }
-
-                foreach (var message in messages)
+                foreach (var message in Data.RelatedMessages)
                 {
                     await message.RefreshData(ServiceControl);
                 }

--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -128,21 +128,19 @@ namespace ServiceInsight.ServiceControl
 
         public async Task<SagaData> GetSagaById(Guid sagaId)
         {
-            var getSagaData =
-                GetModel<SagaData>(
-                    new RestRequestWithCache(string.Format(SagaEndpoint, sagaId),
-                        RestRequestWithCache.CacheStyle.IfNotModified), truncateLargeLists: true);
+            var getSagaData = GetModel<SagaData>(new RestRequestWithCache(string.Format(SagaEndpoint, sagaId), RestRequestWithCache.CacheStyle.IfNotModified), truncateLargeLists: true);
 
             var getMessageData = GetAuditMessages(searchQuery: sagaId.ToString());
 
             await Task.WhenAll(getSagaData, getMessageData).ConfigureAwait(false);
             
-            if (getSagaData.Result == null)
+            var sagaData = getSagaData.Result;
+
+            if (sagaData == null)
             {
                 return new SagaData();
             }
 
-            var sagaData = getSagaData.Result;
             var messageData = getMessageData.Result;
 
             if (sagaData.Changes != null && messageData?.Result != null)


### PR DESCRIPTION
Pushes the query from https://github.com/Particular/ServiceInsight/pull/985 down to the ServiceControl layer. It is not possible to get saga message data without also retrieving the body uls. 