### PR TITLE
Read license from PARTICULARSOFTWARE_LICENSE environment variable

### DIFF
--- a/src/ServiceInsight.Licensing/ServiceInsight.Licensing.csproj
+++ b/src/ServiceInsight.Licensing/ServiceInsight.Licensing.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Particular.CodeRules" Version="0.7.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="3.4.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.5.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>


### PR DESCRIPTION
This change allows ServiceInsight to read a license stored in the PARTICULARSOFTWARE_LICENSE environment variable.