### PR TITLE
Scope mutex and named pipe to the current user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 5.0.203 # should be 5.0.x when the runner image is updated to VS 16.10 or higher
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Build

--- a/src/ServiceInsight.Tests/ShellViewModelTests.cs
+++ b/src/ServiceInsight.Tests/ShellViewModelTests.cs
@@ -21,10 +21,10 @@
     using ServiceInsight.Framework.Licensing;
     using ServiceInsight.Framework.Settings;
     using ServiceInsight.Framework.UI.ScreenManager;
+    using ServiceInsight.Startup;
     using Settings;
     using Shell;
     using Shouldly;
-    using Startup;
 
     public interface IShellViewStub : IShellView
     {

--- a/src/ServiceInsight.Tests/Startup/PipeNameTests.cs
+++ b/src/ServiceInsight.Tests/Startup/PipeNameTests.cs
@@ -1,0 +1,16 @@
+﻿namespace ServiceInsight.Tests
+{
+    using System;
+    using NUnit.Framework;
+    using ServiceInsight.Startup;
+
+    [TestFixture]
+    public class PipeNameTests
+    {
+        [Test]
+        public void Should_return_pipe_name_with_the_current_user_username()
+        {
+            Assert.AreEqual($"ServiceInsight-{Environment.UserName}", PipeName.Value);
+        }
+    }
+}

--- a/src/ServiceInsight/App.xaml.cs
+++ b/src/ServiceInsight/App.xaml.cs
@@ -12,12 +12,13 @@
 
     public partial class App
     {
-        bool createNew;
-        Mutex mutex;
+        readonly bool createNew;
+        readonly Mutex mutex;
 
         public App()
         {
-            mutex = new Mutex(true, "ServiceInsight", out createNew);
+            mutex = new Mutex(true, "Local\\ServiceInsight", out createNew);
+
             if (createNew)
             {
                 LoggingConfig.SetupLogging();

--- a/src/ServiceInsight/Startup/CommandLineArgParser.cs
+++ b/src/ServiceInsight/Startup/CommandLineArgParser.cs
@@ -1,9 +1,9 @@
 ﻿namespace ServiceInsight.Startup
 {
     using System;
-    using System.IO.Pipes;
     using System.Collections.Generic;
     using System.IO;
+    using System.IO.Pipes;
     using Anotar.Serilog;
     using ServiceInsight.Models;
 
@@ -13,8 +13,8 @@
         const char TokenSeparator = '&';
         const char KeyValueSeparator = '=';
 
-        EnvironmentWrapper environment;
-        IList<string> unsupportedKeys;
+        readonly EnvironmentWrapper environment;
+        readonly IList<string> unsupportedKeys;
 
         public CommandLineOptions ParsedOptions { get; private set; }
 
@@ -44,7 +44,7 @@
 
             try
             {
-                using (var pipe = new NamedPipeClientStream(".", $"ServiceInsight-{Environment.UserName}", PipeDirection.Out))
+                using (var pipe = new NamedPipeClientStream(".", PipeName.Value, PipeDirection.Out))
                 using (var writer = new StreamWriter(pipe))
                 {
                     pipe.Connect(1000);

--- a/src/ServiceInsight/Startup/CommandLineArgParser.cs
+++ b/src/ServiceInsight/Startup/CommandLineArgParser.cs
@@ -44,7 +44,7 @@
 
             try
             {
-                using (var pipe = new NamedPipeClientStream(".", "ServiceInsight", PipeDirection.Out))
+                using (var pipe = new NamedPipeClientStream(".", $"ServiceInsight-{Environment.UserName}", PipeDirection.Out))
                 using (var writer = new StreamWriter(pipe))
                 {
                     pipe.Connect(1000);

--- a/src/ServiceInsight/Startup/PipeName.cs
+++ b/src/ServiceInsight/Startup/PipeName.cs
@@ -1,0 +1,15 @@
+﻿namespace ServiceInsight.Startup
+{
+    using System;
+
+    /// <summary>
+    /// NamedPipeServerStream pipe name.
+    /// </summary>
+    public static class PipeName
+    {
+        /// <summary>
+        /// "ServiceInsight-username" where username is the Windows currently logged in user username.
+        /// </summary>
+        public static string Value { get; } = $"ServiceInsight-{Environment.UserName}";
+    }
+}

--- a/src/ServiceInsight/Startup/StartupConfigListener.cs
+++ b/src/ServiceInsight/Startup/StartupConfigListener.cs
@@ -40,7 +40,7 @@
 
         static async Task Handle(IEventAggregator eventAggregator, CommandLineArgParser parser, CancellationToken cancellationToken)
         {
-            using (var pipe = new NamedPipeServerStream("ServiceInsight", PipeDirection.In, 1, PipeTransmissionMode.Byte))
+            using (var pipe = new NamedPipeServerStream($"ServiceInsight-{Environment.UserName}", PipeDirection.In, 1, PipeTransmissionMode.Byte))
             using (cancellationToken.Register(() => Disconnect(pipe)))
             {
                 await pipe.WaitForConnectionAsync(cancellationToken);

--- a/src/ServiceInsight/Startup/StartupConfigListener.cs
+++ b/src/ServiceInsight/Startup/StartupConfigListener.cs
@@ -1,15 +1,12 @@
 ﻿namespace ServiceInsight.Startup
 {
-    using System.IO.Pipes;
     using System;
     using System.IO;
-    using System.Net;
-    using System.Net.Sockets;
+    using System.IO.Pipes;
     using System.Threading;
     using System.Threading.Tasks;
     using Caliburn.Micro;
     using ServiceInsight.Framework.Events;
-    using ServiceInsight.Framework.Settings;
 
     public class StartupConfigListener
     {
@@ -40,7 +37,7 @@
 
         static async Task Handle(IEventAggregator eventAggregator, CommandLineArgParser parser, CancellationToken cancellationToken)
         {
-            using (var pipe = new NamedPipeServerStream($"ServiceInsight-{Environment.UserName}", PipeDirection.In, 1, PipeTransmissionMode.Byte))
+            using (var pipe = new NamedPipeServerStream(PipeName.Value, PipeDirection.In, 1, PipeTransmissionMode.Byte))
             using (cancellationToken.Register(() => Disconnect(pipe)))
             {
                 await pipe.WaitForConnectionAsync(cancellationToken);


### PR DESCRIPTION
_Resolves https://github.com/Particular/ServiceInsight/issues/1033_

- Scopes mutex to the local user/session
- Appends current username to the named pipe to make it distinct per user session