### PR TITLE
Refresh status icon when retrying message

### DIFF
--- a/src/ServiceInsight/MessageList/MessageListViewModel.cs
+++ b/src/ServiceInsight/MessageList/MessageListViewModel.cs
@@ -216,6 +216,7 @@
             if (msg != null)
             {
                 msg.Status = MessageStatus.RetryIssued;
+                msg.NotifyOfPropertyChange(nameof(msg.Status));
             }
         }
 


### PR DESCRIPTION
I noticed that the status icon on the messages list would not change when retrying a message (unless the data would have changed on the SC database). The code seemed to already contain logic to change the status until the data is reloaded, but the change would not apply to the UI. Raising a property changed event does solve the issue and the icon does refresh whether you retry in the messages view or in any other view that supports retrying.