### PR TITLE
Update Advanced Installer to 18.8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
       - name: Setup Advanced Installer
         run: |
-          $version = 18.4
+          $version = "18.8.1"
           choco install advanced-installer --version=$version
           & "C:\Program Files (x86)\Caphyon\Advanced Installer $version\bin\x86\AdvancedInstaller.com" /register ${{ secrets.ADVANCED_INSTALLER_LICENSE_KEY }}
       - name: Prepare AIP file


### PR DESCRIPTION
This should fix the problem with Advanced Installer not signing the binaries properly.