### PR TITLE
Allows linking nodes in the message flow view as a fallback when no link could be established on OriginatingEndpoint / ProcessingEndpoint mismatch

### DIFF
--- a/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
+++ b/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
@@ -13,6 +13,7 @@
     using Serilog.Events;
     using Serilog.Filters;
     using ServiceControl;
+    using ServiceInsight.MessageFlow;
 
     public static class LoggingConfig
     {
@@ -31,7 +32,7 @@
                 .WriteTo.Trace(outputTemplate: "[{Level}] ({SourceContext}) {Message}{NewLine}{Exception}")
                 .WriteTo.Logger(lc => lc
                     .MinimumLevel.Verbose()
-                    .Filter.ByIncludingOnly(MatchingTypes(typeof(DefaultServiceControl), typeof(CustomMessageViewerResolver)))
+                    .Filter.ByIncludingOnly(MatchingTypes(typeof(DefaultServiceControl), typeof(CustomMessageViewerResolver), typeof(MessageFlowViewModel)))
                     .WriteTo.Observers(logEvents => logEvents
                         .ObserveOn(TaskPoolScheduler.Default)
                         .Do(LogWindowViewModel.LogObserver)

--- a/src/ServiceInsight/Framework/UI/ScreenManager/ServiceInsightWindowManager.cs
+++ b/src/ServiceInsight/Framework/UI/ScreenManager/ServiceInsightWindowManager.cs
@@ -107,7 +107,6 @@
 
         static MessageChoice GetMessageChoice(MessageBoxButton button)
         {
-            //TODO: Use map to avoid switch/case
             MessageChoice choices;
             switch (button)
             {

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -287,11 +287,11 @@
 
                 if (!parentMessages.Any())
                 {
-                    LogTo.Error("No parent could be resolved for message {0} which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
+                    LogTo.Information("No parent could be resolved for the message with Id '{0}' which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
                 }
                 else if (parentMessages.Count() > 1)
                 {
-                    LogTo.Error("Multiple parents matched for {0} possibly due to more-than-once processing, linking to all as unknown which processing attemps generated the message.", msg.Message.MessageId);
+                    LogTo.Error("Multiple parents matched for message id '{0}' possibly due to more-than-once processing, linking to all as it is unknown which processing attempt generated the message.", msg.Message.MessageId);
                 }
 
                 foreach (var parentMessage in parentMessages)

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -282,17 +282,17 @@
 
                     if (parentMessages.Any())
                     {
-                        LogTo.Warning("Fall back to match only on RelatedToMessageId for message {0} matched but link could be invalid.", msg.Message.MessageId);
+                        LogTo.Warning("Fall back to match only on RelatedToMessageId for message with Id '{MessageId}' matched but link could be invalid.", msg.Message.MessageId);
                     }
                 }
 
                 if (!parentMessages.Any())
                 {
-                    LogTo.Information("No parent could be resolved for the message with Id '{0}' which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
+                    LogTo.Information("No parent could be resolved for the message with Id '{MessageId}' which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
                 }
                 else if (parentMessages.Count() > 1)
                 {
-                    LogTo.Error("Multiple parents matched for message id '{0}' possibly due to more-than-once processing, linking to all as it is unknown which processing attempt generated the message.", msg.Message.MessageId);
+                    LogTo.Error("Multiple parents matched for message id '{MessageId}' possibly due to more-than-once processing, linking to all as it is unknown which processing attempt generated the message.", msg.Message.MessageId);
                 }
 
                 foreach (var parentMessage in parentMessages)

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -286,13 +286,17 @@
                     }
                 }
 
-                if (!parentMessages.Any())
+                switch (parentMessages.Length)
                 {
-                    LogTo.Information("No parent could be resolved for the message with Id '{MessageId}' which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
-                }
-                else if (parentMessages.Count() > 1)
-                {
-                    LogTo.Error("Multiple parents matched for message id '{MessageId}' possibly due to more-than-once processing, linking to all as it is unknown which processing attempt generated the message.", msg.Message.MessageId);
+                    case 0:
+                        LogTo.Information("No parent could be resolved for the message with Id '{MessageId}' which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
+                        break;
+                    case 1:
+                        // Log nothing, this is what it should be
+                        break;
+                    default:
+                        LogTo.Error("Multiple parents matched for message id '{MessageId}' possibly due to more-than-once processing, linking to all as it is unknown which processing attempt generated the message.", msg.Message.MessageId);
+                        break;
                 }
 
                 foreach (var parentMessage in parentMessages)

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -278,7 +278,7 @@
                     parentMessages = nodeMap.Values.Where(m =>
                         m.Message != null && m.Message.ReceivingEndpoint != null && m.Message.SendingEndpoint != null &&
                         m.Message.MessageId == msg.Message.RelatedToMessageId && m.Message.MessageIntent != MessageIntent.Publish
-                        );
+                        ).ToArray();
 
                     if (parentMessages.Any())
                     {

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -278,7 +278,7 @@
                         m.Message != null && m.Message.ReceivingEndpoint != null && m.Message.SendingEndpoint != null &&
                         m.Message.MessageId == msg.Message.RelatedToMessageId && m.Message.MessageIntent != MessageIntent.Publish
                         );
-                    
+
                     if (parentMessages.Any())
                     {
                         LogTo.Warning("Fall back to match only on RelatedToMessageId for message {0} matched but link could be invalid.", msg.Message.MessageId);

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -269,7 +269,8 @@
                     m.Message != null && m.Message.ReceivingEndpoint != null && m.Message.SendingEndpoint != null
                     && m.Message.MessageId == msg.Message.RelatedToMessageId
                     && m.Message.ReceivingEndpoint.Name == msg.Message.SendingEndpoint.Name // Needed with publishes as identical events can be consumed by multiple endpoints
-                    );
+                    )
+                    .ToArray();
 
                 // Fallback, get "parent" when originating message is not an event (publish)
                 if (!parentMessages.Any())


### PR DESCRIPTION
- Resolves: https://github.com/Particular/ServiceInsight/issues/1196

In order to link nodes the following must be true:

```c#
child.RelatedTo == parent.Id && child.OriginatingEndpoint == parent.ProcessingEndpoint
```    

However, in situaties where only processed messages can be linked based on RelatedTo these messages remain unlinked in the message flow view.

Before:

![image](https://user-images.githubusercontent.com/152998/153246024-a1174efa-6b10-4337-8f11-1bfc88cdf1ad.png)

After:

![image](https://user-images.githubusercontent.com/152998/153246152-e8d38078-a4fa-4c6b-9b94-384fc6957697.png)

Logic is written in such a way that the fallback only happens if intent not equal to publish. Meaning, only messages and commands as these SHOULD only have one processing endpoint


## Implications

This is a fallback, the default linking behavior remains the same is the message flow  is purely passing only NServiceBus endpoints but adds linking when that is not always the case (i.e. native integration).