### PR TITLE
Raising `NotSupportException` instead of `NotImplementedException`

### DIFF
--- a/src/ServiceInsight/Framework/Settings/RegistrySettingsStore.cs
+++ b/src/ServiceInsight/Framework/Settings/RegistrySettingsStore.cs
@@ -23,7 +23,7 @@
 
         public void Save<T>(string key, T settings)
         {
-            throw new NotImplementedException(); //Do we even need this??
+            throw new NotSupportedException(); //Do we even need this??
         }
 
         public T Load<T>(string key, IList<SettingDescriptor> metadata) where T : new()

--- a/src/ServiceInsight/SequenceDiagram/Converter/ElementHeightConverter.cs
+++ b/src/ServiceInsight/SequenceDiagram/Converter/ElementHeightConverter.cs
@@ -18,7 +18,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/SequenceDiagram/Converter/SmartWrapConverter.cs
+++ b/src/ServiceInsight/SequenceDiagram/Converter/SmartWrapConverter.cs
@@ -40,7 +40,7 @@ namespace ServiceInsight.SequenceDiagram.Converter
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/Shell/AppExceptionHandler.cs
+++ b/src/ServiceInsight/Shell/AppExceptionHandler.cs
@@ -46,7 +46,7 @@
             }
         }
 
-        bool IsSoftError(Exception rootError) => rootError is NotImplementedException;
+        bool IsSoftError(Exception rootError) => rootError is NotSupportedException;
 
         void ShowWarning(Exception error)
         {

--- a/src/ServiceInsight/ValueConverters/BitmapToGlyphConverter.cs
+++ b/src/ServiceInsight/ValueConverters/BitmapToGlyphConverter.cs
@@ -16,7 +16,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/BoolToStrokeDashArrayConverter.cs
+++ b/src/ServiceInsight/ValueConverters/BoolToStrokeDashArrayConverter.cs
@@ -25,7 +25,7 @@ namespace ServiceInsight.ValueConverters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/ByteToCharConverter.cs
+++ b/src/ServiceInsight/ValueConverters/ByteToCharConverter.cs
@@ -26,7 +26,7 @@ namespace ServiceInsight.ValueConverters
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/ByteToHexConverter.cs
+++ b/src/ServiceInsight/ValueConverters/ByteToHexConverter.cs
@@ -17,7 +17,7 @@ namespace ServiceInsight.ValueConverters
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/DateStatusToBrushConverter.cs
+++ b/src/ServiceInsight/ValueConverters/DateStatusToBrushConverter.cs
@@ -25,7 +25,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/DrawingNameToImageSourceConverter.cs
+++ b/src/ServiceInsight/ValueConverters/DrawingNameToImageSourceConverter.cs
@@ -21,7 +21,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/EndSegmentValueConverter.cs
+++ b/src/ServiceInsight/ValueConverters/EndSegmentValueConverter.cs
@@ -31,7 +31,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/EnumToVisibilityConverter.cs
+++ b/src/ServiceInsight/ValueConverters/EnumToVisibilityConverter.cs
@@ -42,7 +42,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/MathConverter.cs
+++ b/src/ServiceInsight/ValueConverters/MathConverter.cs
@@ -19,7 +19,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
@@ -64,7 +64,7 @@
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public override object ProvideValue(IServiceProvider serviceProvider) => this;

--- a/src/ServiceInsight/ValueConverters/NullToVisibilityConverter.cs
+++ b/src/ServiceInsight/ValueConverters/NullToVisibilityConverter.cs
@@ -11,7 +11,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/PopupMenuItemCountVisibleConverter.cs
+++ b/src/ServiceInsight/ValueConverters/PopupMenuItemCountVisibleConverter.cs
@@ -15,7 +15,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/StartSegmentValueConverter.cs
+++ b/src/ServiceInsight/ValueConverters/StartSegmentValueConverter.cs
@@ -25,7 +25,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/StatusToBrushConverter.cs
+++ b/src/ServiceInsight/ValueConverters/StatusToBrushConverter.cs
@@ -36,7 +36,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/StringEmptyOrNullToVisibilityConverter.cs
+++ b/src/ServiceInsight/ValueConverters/StringEmptyOrNullToVisibilityConverter.cs
@@ -15,7 +15,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/TimeSpanHumanizedConverter.cs
+++ b/src/ServiceInsight/ValueConverters/TimeSpanHumanizedConverter.cs
@@ -17,7 +17,7 @@ namespace ServiceInsight.ValueConverters
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }

--- a/src/ServiceInsight/ValueConverters/ZoomToCancelScaleConverter.cs
+++ b/src/ServiceInsight/ValueConverters/ZoomToCancelScaleConverter.cs
@@ -14,7 +14,7 @@
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
     }
 }


### PR DESCRIPTION
Releases should not have code that throws `NotImplementedException`. `NotImplementedException` means that implementation is missing and should exist (as in, todo) while `NotSupportException` means a conscious decision is made to not implement thus not support the API. 