### PR TITLE
Disabling an option to multiselect rows on the grid

### DIFF
--- a/src/ServiceInsight/MessageList/MessageListView.xaml
+++ b/src/ServiceInsight/MessageList/MessageListView.xaml
@@ -64,7 +64,7 @@
                              IsHitTestVisible="{Binding WorkInProgress,
                                                         Converter={StaticResource BooleanInverseConverter}}"
                              ItemsSource="{Binding Rows}"
-                             SelectionMode="Row"
+                             SelectionMode="None"
                              SelectedItem="{Binding Selection.SelectedMessage, Delay=50}"
                              ShowLoadingPanel="{Binding WorkInProgress}"
                              StartSorting="Grid_OnStartSorting">


### PR DESCRIPTION
The issue was raised: one can select multiple rows on the message list and click retry, but only one message is retried. Currently, mutli-selection on the grid is not handled in any way. Message selected on the list is displayed in the details view (flow diagram, sequence, headers, body), without changing the way how the application work it would be hard to make the multi-select behavior to work in a reasonable way.

