### PR TITLE
Check if a connection to a ServiceControl instance is already present

### DIFF
--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -160,9 +160,19 @@
             }
         }
 
+        bool IsConnectedToServiceControlNode(string url)
+        {
+            return Items.OfType<ServiceControlExplorerItem>().Any(ei => ei.Url == url);
+        }
+
         public async Task ConnectToService(string url)
         {
             if (!url.IsValidUrl())
+            {
+                return;
+            }
+
+            if (IsConnectedToServiceControlNode(url))
             {
                 return;
             }

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -160,9 +160,9 @@
             }
         }
 
-        bool IsConnectedToServiceControlNode(string url)
+        ServiceControlExplorerItem SelectConnectedServiceControlNode(string url)
         {
-            return Items.OfType<ServiceControlExplorerItem>().Any(ei => ei.Url == url);
+            return Items.OfType<ServiceControlExplorerItem>().SingleOrDefault(ei => ei.Url == url);
         }
 
         public async Task ConnectToService(string url)
@@ -172,8 +172,11 @@
                 return;
             }
 
-            if (IsConnectedToServiceControlNode(url))
+            var connectedNode = SelectConnectedServiceControlNode(url);
+            if (connectedNode != null)
             {
+                ExpandServiceControlNode(connectedNode);
+                SelectDefaultEndpoint(connectedNode);
                 return;
             }
 


### PR DESCRIPTION
- Fix #990 

Before adding a new connection, the endpoint explorer checks if any of the ServiceControl nodes already connected matches the unique URL. If that's the case, it skips adding the new connection.