### PR TITLE
Messages window no longer multiple rows as selected as user scrolls through data

### DIFF
--- a/src/ServiceInsight/App.xaml
+++ b/src/ServiceInsight/App.xaml
@@ -59,8 +59,6 @@
                         <GradientStop Offset="0" Color="#FFFFFAE9" />
                         <GradientStop Offset="1" Color="#FFFFE8A6" />
                     </LinearGradientBrush>
-                    <SolidColorBrush x:Key="FocusedRowBackgroundBrush" Color="#222222" />
-                    <SolidColorBrush x:Key="FocusedRowForegroundBrush" Color="White" />
                     <SolidColorBrush x:Key="ZoomBoxTicksBrush" Color="#FF000000" />
                     <SolidColorBrush x:Key="ZoomBoxButtonBorderBrush" Color="#FFAAACA5" />
                     <SolidColorBrush x:Key="DialogButtonHoverBrush" Color="#FFBCC7D8" />

--- a/src/ServiceInsight/App.xaml
+++ b/src/ServiceInsight/App.xaml
@@ -59,6 +59,8 @@
                         <GradientStop Offset="0" Color="#FFFFFAE9" />
                         <GradientStop Offset="1" Color="#FFFFE8A6" />
                     </LinearGradientBrush>
+                    <SolidColorBrush x:Key="FocusedRowBackgroundBrush" Color="#222222" />
+                    <SolidColorBrush x:Key="FocusedRowForegroundBrush" Color="White" />
                     <SolidColorBrush x:Key="ZoomBoxTicksBrush" Color="#FF000000" />
                     <SolidColorBrush x:Key="ZoomBoxButtonBorderBrush" Color="#FFAAACA5" />
                     <SolidColorBrush x:Key="DialogButtonHoverBrush" Color="#FFBCC7D8" />

--- a/src/ServiceInsight/MessageList/MessageListView.xaml
+++ b/src/ServiceInsight/MessageList/MessageListView.xaml
@@ -12,20 +12,6 @@
              d:DesignHeight="200"
              d:DesignWidth="500"
              mc:Ignorable="d">
-    <UserControl.Resources>
-        <Style x:Key="FocusedRowStyle" TargetType="dxg:RowControl">
-            <Style.Triggers>
-                <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
-                    <Setter Property="Background" Value="{StaticResource FocusedRowBackgroundBrush}" />
-                    <Setter Property="Foreground" Value="{StaticResource FocusedRowForegroundBrush}" />
-                </DataTrigger>
-                <Trigger Property="dxg:DataViewBase.IsFocused" Value="True">
-                    <Setter Property="Background" Value="{StaticResource FocusedRowBackgroundBrush}" />
-                    <Setter Property="Foreground" Value="{StaticResource FocusedRowForegroundBrush}" />
-                </Trigger>
-            </Style.Triggers>
-        </Style>
-    </UserControl.Resources>
     <dxb:BarManager>
         <dxb:BarManager.Items>
             <dxb:BarButtonItem Name="retryMessage"
@@ -217,7 +203,7 @@
                                    NavigationStyle="Row"
                                    ShowGroupPanel="False"
                                    ShowIndicator="False"
-                                   RowStyle="{StaticResource FocusedRowStyle}"/>
+                                   />
                 </dxg:GridControl.View>
             </dxg:GridControl>
         </Grid>

--- a/src/ServiceInsight/MessageList/MessageListView.xaml
+++ b/src/ServiceInsight/MessageList/MessageListView.xaml
@@ -12,6 +12,16 @@
              d:DesignHeight="200"
              d:DesignWidth="500"
              mc:Ignorable="d">
+    <UserControl.Resources>
+        <Style x:Key="FocusedRowStyle" TargetType="dxg:RowControl">
+            <Style.Triggers>
+                <DataTrigger Binding="{Binding Path=IsSelected}" Value="True">
+                    <Setter Property="Background" Value="{StaticResource FocusedRowBackgroundBrush}" />
+                    <Setter Property="Foreground" Value="{StaticResource FocusedRowForegroundBrush}" />
+                </DataTrigger>
+            </Style.Triggers>
+        </Style>
+    </UserControl.Resources>
     <dxb:BarManager>
         <dxb:BarManager.Items>
             <dxb:BarButtonItem Name="retryMessage"
@@ -203,7 +213,7 @@
                                    NavigationStyle="Row"
                                    ShowGroupPanel="False"
                                    ShowIndicator="False"
-                                   />
+                                   RowStyle="{StaticResource FocusedRowStyle}"/>
                 </dxg:GridControl.View>
             </dxg:GridControl>
         </Grid>


### PR DESCRIPTION
Fixes #882, styling logic resulted in multiple rows to be selected based on `dxg:DataViewBase.IsFocused` which is flawed. Also removed the black styling of the row to make it unified with other table/grid controls.

Resolves this behavior:

![Gl7aepMUQs](https://user-images.githubusercontent.com/152998/171618624-95ad9917-8381-4955-8496-5653165ad1fb.gif)
