### PR TITLE
Fix search from command line

### DIFF
--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -291,8 +291,9 @@
 
         public async Task Handle(ConfigurationUpdated message)
         {
+            Parent.SearchInProgress = true;
             await ConnectToService(commandLineParser.ParsedOptions.EndpointUri.ToString());
-            await Parent.PostConfigurationUpdate();
+            await Parent.PerformSearchAndInitializeRefreshTimer();
         }
     }
 }

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -162,7 +162,7 @@
 
         ServiceControlExplorerItem SelectConnectedServiceControlNode(string url)
         {
-            return Items.OfType<ServiceControlExplorerItem>().SingleOrDefault(ei => ei.Url == url);
+            return Items.OfType<ServiceControlExplorerItem>().SingleOrDefault(ei => ei.Url.TrimEnd('/') == url.TrimEnd('/'));
         }
 
         public async Task ConnectToService(string url)

--- a/src/ServiceInsight/MessageList/MessageListViewModel.cs
+++ b/src/ServiceInsight/MessageList/MessageListViewModel.cs
@@ -194,6 +194,11 @@
             selectedExplorerItem = @event.SelectedExplorerItem;
             ServiceControl = @event.SelectedExplorerItem.GetServiceControlClient(clientRegistry);
 
+            if (Parent.SearchInProgress)
+            {
+                return;
+            }
+
             if (ServiceControl != null)
             {
                 await RefreshMessages();

--- a/src/ServiceInsight/Shell/ShellViewModel.cs
+++ b/src/ServiceInsight/Shell/ShellViewModel.cs
@@ -477,10 +477,19 @@
             DisplayRegistrationStatus();
         }
 
-        public async Task PostConfigurationUpdate()
+        public async Task PerformSearchAndInitializeRefreshTimer()
         {
-            await Messages.SearchBar.PerformCommandLineSearch();
+            try
+            {
+                await Messages.SearchBar.PerformCommandLineSearch();
+            }
+            finally
+            {
+                SearchInProgress = false;
+            }
             InitializeAutoRefreshTimer();
         }
+
+        public bool SearchInProgress { get; set; }
     }
 }


### PR DESCRIPTION
This is a dirty trick to fix #1211.

As described in the issue when ServicePulse requires to execute a search ServiceInsight also tries to select a node in the Endpoint explorer. When that happens the messages list view reacts and tries to load messages for the selected node. At the time, ServiceInsight performs a search based on ServicePulse arguments. The search is faster than the messages refresh; thus, the messages list gets replaced by the operation that finishes last, which is always performed by the messages list view overwriting the search results.