### PR TITLE
Allows linking nodes in the message flow view as a fallback when no link could be established on OriginatingEndpoint / ProcessingEndpoint mismatch

### DIFF
--- a/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
+++ b/src/ServiceInsight/Framework/Logging/LoggingConfig.cs
@@ -13,6 +13,7 @@
     using Serilog.Events;
     using Serilog.Filters;
     using ServiceControl;
+    using ServiceInsight.MessageFlow;
 
     public static class LoggingConfig
     {
@@ -31,7 +32,7 @@
                 .WriteTo.Trace(outputTemplate: "[{Level}] ({SourceContext}) {Message}{NewLine}{Exception}")
                 .WriteTo.Logger(lc => lc
                     .MinimumLevel.Verbose()
-                    .Filter.ByIncludingOnly(MatchingTypes(typeof(DefaultServiceControl), typeof(CustomMessageViewerResolver)))
+                    .Filter.ByIncludingOnly(MatchingTypes(typeof(DefaultServiceControl), typeof(CustomMessageViewerResolver), typeof(MessageFlowViewModel)))
                     .WriteTo.Observers(logEvents => logEvents
                         .ObserveOn(TaskPoolScheduler.Default)
                         .Do(LogWindowViewModel.LogObserver)

--- a/src/ServiceInsight/Framework/UI/ScreenManager/ServiceInsightWindowManager.cs
+++ b/src/ServiceInsight/Framework/UI/ScreenManager/ServiceInsightWindowManager.cs
@@ -107,7 +107,6 @@
 
         static MessageChoice GetMessageChoice(MessageBoxButton button)
         {
-            //TODO: Use map to avoid switch/case
             MessageChoice choices;
             switch (button)
             {

--- a/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
+++ b/src/ServiceInsight/MessageFlow/MessageFlowViewModel.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using System.Windows.Input;
+    using Anotar.Serilog;
     using Autofac;
     using Caliburn.Micro;
     using Mindscape.WpfDiagramming;
@@ -259,18 +260,44 @@
         {
             foreach (var msg in relatedMessagesTask)
             {
-                if (msg.Message.RelatedToMessageId == null &&
-                    msg.Message.RelatedToMessageId != msg.Message.MessageId)
+                if (string.IsNullOrEmpty(msg.Message.RelatedToMessageId) && msg.Message.RelatedToMessageId != msg.Message.MessageId)
                 {
                     continue;
                 }
 
-                // [CM] I don't know how it's happening, but a user reported an
-                // error where multiple results were returned from this query.
                 var parentMessages = nodeMap.Values.Where(m =>
-                    m.Message != null && m.Message.ReceivingEndpoint != null && m.Message.SendingEndpoint != null &&
-                    m.Message.MessageId == msg.Message.RelatedToMessageId &&
-                    m.Message.ReceivingEndpoint.Name == msg.Message.SendingEndpoint.Name);
+                    m.Message != null && m.Message.ReceivingEndpoint != null && m.Message.SendingEndpoint != null
+                    && m.Message.MessageId == msg.Message.RelatedToMessageId
+                    && m.Message.ReceivingEndpoint.Name == msg.Message.SendingEndpoint.Name // Needed with publishes as identical events can be consumed by multiple endpoints
+                    )
+                    .ToArray();
+
+                // Fallback, get "parent" when originating message is not an event (publish)
+                if (!parentMessages.Any())
+                {
+                    parentMessages = nodeMap.Values.Where(m =>
+                        m.Message != null && m.Message.ReceivingEndpoint != null && m.Message.SendingEndpoint != null &&
+                        m.Message.MessageId == msg.Message.RelatedToMessageId && m.Message.MessageIntent != MessageIntent.Publish
+                        ).ToArray();
+
+                    if (parentMessages.Any())
+                    {
+                        LogTo.Warning("Fall back to match only on RelatedToMessageId for message with Id '{MessageId}' matched but link could be invalid.", msg.Message.MessageId);
+                    }
+                }
+
+                switch (parentMessages.Length)
+                {
+                    case 0:
+                        LogTo.Information("No parent could be resolved for the message with Id '{MessageId}' which has RelatedToMessageId set. This can happen if the parent has been purged due to retention expiration, an ServiceControl node to be unavailable, or because the parent message not been stored (yet).", msg.Message.MessageId);
+                        break;
+                    case 1:
+                        // Log nothing, this is what it should be
+                        break;
+                    default:
+                        LogTo.Error("Multiple parents matched for message id '{MessageId}' possibly due to more-than-once processing, linking to all as it is unknown which processing attempt generated the message.", msg.Message.MessageId);
+                        break;
+                }
 
                 foreach (var parentMessage in parentMessages)
                 {


### PR DESCRIPTION
Re-doing the changes from pull request https://github.com/Particular/ServiceInsight/pull/1171  into master