### PR TITLE
Use RepoRootDir instead of SolutionDir

### DIFF
--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -27,7 +27,8 @@
       <ResourceFiles Include="res\*.*" />
     </ItemGroup>
     <PropertyGroup>
-      <SetupExeOutputFolder>$(SolutionDir)..\assets\</SetupExeOutputFolder>
+      <RepoRootDir>$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)\..\..\))</RepoRootDir>
+      <SetupExeOutputFolder>$(RepoRootDir)assets\</SetupExeOutputFolder>
       <SetupExeName>ServiceInsight-$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).exe</SetupExeName>
     </PropertyGroup>
     <MakeDir Directories="$(SetupExeOutputFolder)" />
@@ -39,8 +40,8 @@
     <Copy SourceFiles="$(CommandFile)" DestinationFolder="$(IntermediateOutputPath)" />
     <Copy SourceFiles="License.rtf" DestinationFolder="$(IntermediateOutputPath)" />
     <Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(IntermediateOutputPath)res\%(RecursiveDir)" SkipUnchangedFiles="true" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(SolutionDir)Setup -valuetype Folder" />
-    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name SI_PATH -value $(SolutionDir)ServiceInsight\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name PROJECT_PATH -value $(RepoRootDir)src\Setup -valuetype Folder" />
+    <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /NewPathVariable -name SI_PATH -value $(RepoRootDir)src\ServiceInsight\bin\$(Configuration)\$(TargetFramework) -valuetype Folder" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetVersion $(MinVerMajor).$(MinVerMinor).$(MinVerPatch)" />
     <Exec Command="$(AdvancedInstallerExe) /edit $(IntermediateOutputPath)$(AIPFile) /SetPackageName $(SetupExeOutputFolder)$(SetupExeName) -buildname DefaultBuild" />
     <Exec Command="$(AdvancedInstallerExe) /execute $(IntermediateOutputPath)$(AIPFile) $(IntermediateOutputPath)$(CommandFile)" />


### PR DESCRIPTION
This aligns the Setup project with the approach used in ServiceControl, where the required value is set in the project file, so it will always be available regardless of how the project is built.