### PR TITLE
Run non-deploy portions of release workflow when CI workflow runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   release:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: windows-2022
     steps:
       - name: Check for secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,17 @@ jobs:
           name: assets
           path: assets/*
           retention-days: 1
+      - name : Verify release artifact counts
+        shell: pwsh
+        run: |
+          $assetsCount = (Get-ChildItem -Recurse -File assets).Count
+          $expectedAssetsCount = 1
+
+          if ($assetsCount -ne $expectedAssetsCount)
+          {
+              Write-Host Assets: Expected $expectedAssetsCount but found $assetsCount
+              exit -1
+          }
       - name: Deploy
         if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: Particular/push-octopus-package-action@v1.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,25 @@
 name: Release
 on:
   push:
+    branches:
+      - master
+      - release-*
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'
+  pull_request:
+  workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
 jobs:
   release:
     runs-on: windows-2022
     steps:
+      - name: Check for secrets
+        env:
+          SECRETS_AVAILABLE: ${{ secrets.SECRETS_AVAILABLE }}
+        shell: pwsh
+        run: exit $(If ($env:SECRETS_AVAILABLE -eq 'true') { 0 } Else { 1 })
       - name: Checkout
         uses: actions/checkout@v3.5.2
         with:
@@ -43,6 +53,7 @@ jobs:
           path: assets/*
           retention-days: 1
       - name: Deploy
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: Particular/push-octopus-package-action@v1.1.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: msbuild src -p:Configuration=Release -restore -m
       - name: Setup Advanced Installer
         run: |
-          $version = "18.8.1"
+          $version = "20.2.1"
           choco install advanced-installer --version=$version
           & "C:\Program Files (x86)\Caphyon\Advanced Installer $version\bin\x86\AdvancedInstaller.com" /register ${{ secrets.ADVANCED_INSTALLER_LICENSE_KEY }}
       - name: Prepare AIP file


### PR DESCRIPTION
This PR makes the following changes:
- The release workflow now has all the same triggers as the CI workflow, meaning it will run whenever the CI workflow runs.
  - The steps that actually deploy the release artifacts are skipped unless the workflow is triggered from a tag. This means that nothing changes in our release process because of this PR.
  - The release workflow is skipped when Dependabot opens a PR because it would otherwise fail due to the code signing secrets not being available to Dependabot.
- A step to verify the expected number of release artifacts has been added. This means that if something causes the number of artifacts to change, the release workflow will fail. The counts need to be manually adjusted if there is an intentional change to the expected number of artifacts for a release.

The end result of this PR is that you'll see the release workflow running on every PR, making it easy to access release artifacts, like the Windows installer, for testing. This also means that it is easier to prevent the release workflow from being broken accidentally.