### PR TITLE
Date fields inside a message payload are incorrectly parsed in ServiceInsight

### DIFF
--- a/src/ServiceInsight/MessageViewers/JsonViewer/JsonMessageView.xaml.cs
+++ b/src/ServiceInsight/MessageViewers/JsonViewer/JsonMessageView.xaml.cs
@@ -31,7 +31,7 @@
             var text = message;
             try
             {
-                var jObject = JObject.Parse(message);
+                var jObject = JsonConvert.DeserializeObject<JObject>(message, new JsonSerializerSettings { DateParseHandling = DateParseHandling.None });
                 text = jObject.GetFormatted();
             }
             catch (JsonReaderException)


### PR DESCRIPTION
Issue : [Date fields inside a message payload are incorrectly parsed in ServiceInsight](https://github.com/Particular/PlatformBugs/issues/1225)

This PR applies DateParseHandling.None to fix the datetime mismatch while parsing 