### PR TITLE
Delay for 2.5s when there is an error response to prevent a DoS on the API in case of errors.

### DIFF
--- a/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
+++ b/src/ServiceInsight/ServiceControl/DefaultServiceControl.cs
@@ -447,7 +447,7 @@ where T : class, new() => Execute<T, T>(request, response => response.Data, trun
 
             var response = await restClient.ExecuteAsync(request).ConfigureAwait(false);
 
-            RaiseConnectivityIssue(response);
+            await RaiseConnectivityIssue(response).ConfigureAwait(false);
 
             CleanResponse(response);
 
@@ -546,7 +546,7 @@ where T : class, new() => Execute<T, T>(request, response => response.Data, trun
 
             var response = await restClient.ExecuteAsync<T2>(request).ConfigureAwait(false);
 
-            RaiseConnectivityIssue(response);
+            await RaiseConnectivityIssue(response).ConfigureAwait(false);
 
             CleanResponse(response);
 
@@ -599,15 +599,11 @@ where T : class, new() => Execute<T, T>(request, response => response.Data, trun
             return data;
         }
 
-        void RaiseConnectivityIssue(IRestResponse response)
+        async Task RaiseConnectivityIssue(IRestResponse response)
         {
-            if (response?.ErrorException is WebException webException &&
-                webException.Status == WebExceptionStatus.ConnectFailure)
+            if ((response?.ErrorException is WebException webException && webException.Status == WebExceptionStatus.ConnectFailure) || response?.StatusCode == HttpStatusCode.InternalServerError)
             {
-                LogError(response);
-            }
-            else if (response?.StatusCode == HttpStatusCode.InternalServerError)
-            {
+                await Task.Delay(2500).ConfigureAwait(false);
                 LogError(response);
             }
         }


### PR DESCRIPTION
When the ServiceControl API is returning a error response currently SI will immediately do another request. When the service is in a faulty state this results in a massive amount of requests, CPU, RAM, and network IO.

This fix adds a delay in case of an error so that SI will not immediately execute another request and basically executing a DoS on the infrastructure.