### PR TITLE
[SPIKE] Attempts at OpenID

### DIFF
--- a/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
@@ -1,7 +1,5 @@
 ﻿namespace ServiceInsight.ServiceControl
 {
-    using Caliburn.Micro;
-
     public class ServiceControlConnectionProvider
     {
         public ServiceControlConnectionProvider()

--- a/src/ServiceInsight/ServiceControl/SystemBrowser.cs
+++ b/src/ServiceInsight/ServiceControl/SystemBrowser.cs
@@ -1,0 +1,181 @@
+﻿namespace ServiceInsight.ServiceControl
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Net;
+    using System.Net.Sockets;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using IdentityModel.OidcClient.Browser;
+
+    public class SystemBrowser : IBrowser
+    {
+        public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
+        {
+            var result = await RunListener(options, cancellationToken);
+
+            return result;
+        }
+
+        public static async Task<string> GetLocalRedirectUrl()
+        {
+            var selectedPort = await SelectPortAsync();
+            var redirectUrl = $"http://localhost:{selectedPort}/ServiceInsight/";
+            return redirectUrl;
+        }
+
+        public static void OpenBrowser(string url)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true,
+                });
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Process.Start("xdg-open", url);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                Process.Start("open", url);
+            }
+        }
+
+        /// <summary>
+        /// This method is designed to run on a background thread, running a most simple Httplistener
+        /// waiting for the OAUTH code to come back. This method supports cancellation through the provided
+        /// <paramref name="cancellationToken"/> and will throw OperationCancelledException if the operation is cancelled.
+        /// </summary>
+        async Task<BrowserResult> RunListener(BrowserOptions options, CancellationToken cancellationToken)
+        {
+            var loginurl = options.StartUrl;
+            var redirectUrl = options.EndUrl;
+
+            using (var listener = new HttpListener())
+            {
+                listener.Prefixes.Add(redirectUrl);
+                try
+                {
+                    listener.Start();
+                    Debug.WriteLine($"Starting listening for OAUTH code in url {redirectUrl}");
+
+                    // Don't open browser until listener is operating because if we're already logged in response could be immediate
+                    OpenBrowser(loginurl);
+
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        // Wait for the context and possibly the cancellation of the operation.
+                        var contextTask = await GetCancellableTaskAsync(
+                            listener.GetContextAsync(),
+                            cancellationToken);
+
+                        // Awaits the resulting task. If the task is the cancelled one it will throw, otherwise
+                        // it will just return the context.
+                        var context = await contextTask;
+
+                        // Ensure that this is the URL that we expect, Internet Explorer, and possibly other browsers,
+                        // might ask for the favicon or other metadata pages before actually redirecting with the code.
+                        if (context.Request.Url.AbsolutePath != "/ServiceInsight/")
+                        {
+                            Debug.WriteLine($"Got request for path {context.Request.Url}");
+                            using (var response = context.Response)
+                            {
+                                response.StatusCode = 404;
+                            }
+                            continue;
+                        }
+
+                        using (var response = context.Response)
+                        {
+                            response.ContentType = "text/plain";
+                            response.StatusCode = 200;
+                            using (var writer = new StreamWriter(response.OutputStream, Encoding.UTF8))
+                            {
+                                writer.Write("Authentication successful. You can close this browser window.");
+                            }
+                        }
+
+                        // Wait for a bit for the reponse to be sent.
+                        await Task.Delay(500, CancellationToken.None);
+
+                        return new BrowserResult
+                        {
+                            ResultType = BrowserResultType.Success,
+                            Response = context.Request.Url.Query
+                        };
+
+                        var accessCode = context.Request.QueryString["code"];
+                        var error = context.Request.QueryString["error"];
+
+                        // Redirect to the appropiate website depending on success or failure of the login
+                        // operation.
+                        using (var response = context.Response)
+                        {
+                            Debug.WriteLineIf(string.IsNullOrEmpty(accessCode), $"Failed to authenticate the user OAUTH login flow.");
+                            response.StatusCode = 303;
+                            //response.RedirectLocation = string.IsNullOrEmpty(accessCode) ? _failureUrl : _successUrl;
+                        }
+
+                        // Wait for a bit for the reponse to be sent.
+                        await Task.Delay(500, CancellationToken.None);
+
+                        //return new FlowResult { AccessCode = accessCode, Error = error };
+
+                        return new BrowserResult
+                        {
+                            ResultType = !string.IsNullOrEmpty(accessCode) ? BrowserResultType.Success : BrowserResultType.UnknownError,
+                            Response = accessCode
+                        };
+                    }
+                }
+                finally
+                {
+                    Debug.WriteLine($"Shutting down listener for redirect url {redirectUrl}");
+                    listener.Stop();
+                }
+            }
+
+            return new BrowserResult { ResultType = BrowserResultType.UserCancel };
+        }
+
+        /// <summary>
+        /// This method selects a port on which to run.
+        /// </summary>
+        static Task<int> SelectPortAsync()
+        {
+            return Task.Run(() =>
+            {
+                var listener = new TcpListener(IPAddress.Loopback, 0);
+                try
+                {
+                    listener.Start();
+                    return ((IPEndPoint)listener.LocalEndpoint).Port;
+                }
+                finally
+                {
+                    listener.Stop();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Returns a task that can be awaited to get the task with the data. (There are two levels of await here). If
+        /// the operation completed normally then <paramref name="sourceTask"/> is returend and when awaited the result of the
+        /// operation is returned. If the operation is cancelled then a cancelled dummy task is returned, when awaited
+        /// <seealso cref="OperationCanceledException"/> is thrown. This way any task can be made cancellable if the original
+        /// source of the task doesn't support cancellation.
+        /// </summary>
+        static Task<Task<T>> GetCancellableTaskAsync<T>(Task<T> sourceTask, CancellationToken cancellationToken)
+        {
+            var taskSource = new TaskCompletionSource<T>();
+            cancellationToken.Register(() => taskSource.TrySetCanceled());
+            return Task.WhenAny(sourceTask, taskSource.Task);
+        }
+    }
+}

--- a/src/ServiceInsight/ServiceInsight.csproj
+++ b/src/ServiceInsight/ServiceInsight.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -46,6 +46,8 @@
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
     <PackageReference Include="Gong-wpf-dragdrop" Version="3.2.1" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="6.0.0" />
     <PackageReference Include="Mindscape.Raygun4Net" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Nito.Comparers" Version="6.2.2" />
@@ -62,6 +64,7 @@
     <PackageReference Include="Serilog.Sinks.Trace" Version="3.0.0" />
     <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This spike was my unsuccessful attempt to connect ServiceInsight to an Azure Container Apps hosted platform secured by Azure Entra ID login.

The attempted scenario is having ServiceControl deployed to Azure Container Apps, reverse-proxied through a ServicePulse container, with Azure Entra ID authentication added by the Container Apps infrastructure.

The attempted solution would have attempted to detect data from the 401 Unauthorized resopnse in the WWW-Authenticate header, and then attempting to complete an OAuth authentication flow using the [IdentityModel.OidcClient library](https://www.nuget.org/packages/IdentityModel.OidcClient).

If that were successful, it would hypothetically be possible to replace the RestSharp authenticator instance from the default NtlmAuthenticator with an OAuth authenticator that would inject the proper headers into further requests. It may have been necessary to add some sort of middleware to handle renewing tokens before they expire.

## Problems

The OidcClient wants an "Authority" from which it can load a host of information about what the endpoint supports. In the [IdentityModel samples](https://github.com/IdentityModel/IdentityModel.OidcClient.Samples) this is always `https://demo.duendesoftware.com`. Then it adds `/.well-known/openid-configuration` to that Authority and [finds a document](https://demo.duendesoftware.com/.well-known/openid-configuration) where it gets the info it needs.

But from a ServiceInsight connection dialog, we have no idea what the authority will be, given it will be dependent upon waht a customer uses. In my case, I only had the URL `https://login.microsoftonline.com/<our-tenant-id>/oauth2/v2.0/authorize` but this is only one piece of the puzzle. How does one know what part any given URL is the Authority? In the case of Microsoft login, there is an authority at `https://login.microsoftonline.com/<our-tenant-id>/.well-known/openid-configuration`. I guess you could keep moving up a directory at a time looking for the config document and then assume that's the authority.

But even trying that, I ran into other problems. The config document hosted by Microsoft, which I am not posting here because I dont' know to what extent our tenant ID should be kept secret, has an `issuer` defined on `https://sts.windows.net/<tentant-id>/` which IdentityClient complained did not match the Authority URL (which is login.microsoftonline.com).

Attempting to circumvent finding the config in the well-known location by pre-filling the `ProviderInformation` also failed. While it was possible to go through the OAuth flow past logging in on the external browser to the point where the HttpListener on localhost gets the code returned by Microsoft, but it was not possible to turn that code into an access token because of missing information in the configuration.

I chatted with one of the IdentityModel contributors (who I happen to know personally) and he confirmed that the WWW-Authenticate header doesn't always give you the information you need, and you usually need to configure your client application with your Client iD and other parameters anyway. So mostly, the WWW-Authenticate header is useful for finding out you need a token, but not how to get the token.

He also pointed me to this [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#find-your-apps-openid-configuration-document-uri) about how to find your app's OpenID configuration document URI, which is worth saving.

