### PR TITLE
Add ability to use non-default username and password for Windows Auth

### DIFF
--- a/src/ServiceInsight.Tests/ServiceControlConnectionDialogTests.cs
+++ b/src/ServiceInsight.Tests/ServiceControlConnectionDialogTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace ServiceInsight.Tests
 {
+    using System.Security;
     using System.Threading.Tasks;
     using Autofac;
     using Caliburn.Micro;
@@ -62,6 +63,63 @@
             settingsProvider.Received().SaveSettings(Arg.Any<ProfilerSettings>());
             storedSetting.RecentServiceControlEntries.Count.ShouldBe(3);
             storedSetting.RecentServiceControlEntries.ShouldContain(url);
+        }
+
+        [Test]
+        public void Should_store_username_and_password()
+        {
+            // Arrange
+            var provider = new ServiceControlConnectionProvider();
+            var url = "http://localhost:8080/managementApi";
+            var username = "testUser";
+            var password = new SecureString();
+            foreach (char c in "testPassword")
+            {
+                password.AppendChar(c);
+            }
+
+            // Act
+            provider.ConnectTo(url, username, password);
+
+            // Assert
+            provider.Url.ShouldBe(url);
+            provider.Username.ShouldBe(username);
+            provider.Password.ShouldBe(password);
+        }
+
+        [Test]
+        public void Should_indicate_custom_username_password_usage()
+        {
+            // Arrange
+            var provider = new ServiceControlConnectionProvider();
+            var url = "http://localhost:8080/managementApi";
+            var username = "testUser";
+            var password = new SecureString();
+            foreach (char c in "testPassword")
+            {
+                password.AppendChar(c);
+            }
+
+            // Act
+            provider.ConnectTo(url, username, password);
+
+            // Assert
+            provider.UseWindowsAuthCustomUsernamePassword.ShouldBe(true);
+        }
+
+        [Test]
+        public void Should_not_indicate_custom_username_password_usage_when_empty()
+        {
+            // Arrange
+            var provider = new ServiceControlConnectionProvider();
+            var url = "http://localhost:8080/managementApi";
+            var password = new SecureString();
+
+            // Act
+            provider.ConnectTo(url, null, password);
+
+            // Assert
+            provider.UseWindowsAuthCustomUsernamePassword.ShouldBe(false);
         }
 
         ProfilerSettings GetReloadedSettings()

--- a/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
+++ b/src/ServiceInsight/Explorer/EndpointExplorer/EndpointExplorerViewModel.cs
@@ -219,7 +219,15 @@
 
             using (workNotifier.NotifyOfWork($"Verifying ServiceControl availability at {address}"))
             {
-                var serviceControl = clientRegistry.Create(url);
+                IServiceControl serviceControl;
+                if (clientRegistry.IsRegistered(url))
+                {
+                    serviceControl = clientRegistry.GetServiceControl(url);
+                }
+                else
+                {
+                    serviceControl = clientRegistry.Create(url);
+                }
                 (available, address) = await serviceControl.IsAlive();
             }
 

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -11,6 +11,7 @@
     using ServiceInsight.Framework.Licensing;
     using ServiceInsight.Framework.MessageDecoders;
     using ServiceInsight.Startup;
+    using System.Security;
 
     public class CoreModule : Module
     {
@@ -26,7 +27,7 @@
             builder.RegisterType<ServiceControlConnectionProvider>().InstancePerDependency();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerDependency();
             builder.RegisterType<ServiceControlClientRegistry>().AsSelf().SingleInstance();
-            builder.Register<Func<string, string, string, IServiceControl>>(c =>
+            builder.Register<Func<string, string, SecureString, IServiceControl>>(c =>
             {
                 var context = c.Resolve<IComponentContext>();
 

--- a/src/ServiceInsight/Framework/Modules/CoreModule.cs
+++ b/src/ServiceInsight/Framework/Modules/CoreModule.cs
@@ -26,14 +26,14 @@
             builder.RegisterType<ServiceControlConnectionProvider>().InstancePerDependency();
             builder.RegisterType<DefaultServiceControl>().As<IServiceControl>().InstancePerDependency();
             builder.RegisterType<ServiceControlClientRegistry>().AsSelf().SingleInstance();
-            builder.Register<Func<string, IServiceControl>>(c =>
+            builder.Register<Func<string, string, string, IServiceControl>>(c =>
             {
                 var context = c.Resolve<IComponentContext>();
 
-                return url =>
+                return (url, username, password) =>
                 {
                     var connectionProvider = new ServiceControlConnectionProvider();
-                    connectionProvider.ConnectTo(url);
+                    connectionProvider.ConnectTo(url, username, password);
 
                     return context.Resolve<IServiceControl>(new TypedParameter(typeof(ServiceControlConnectionProvider), connectionProvider));
                 };

--- a/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
@@ -1,12 +1,14 @@
 ﻿namespace ServiceInsight.ServiceControl
 {
+    using System.Security;
+
     public class ServiceControlConnectionProvider
     {
         public ServiceControlConnectionProvider()
         {
         }
 
-        public void ConnectTo(string url, string username = null, string password = null)
+        public void ConnectTo(string url, string username = null, SecureString password = null)
         {
             Url = url;
             Username = username;
@@ -16,7 +18,7 @@
 
         public string Url { get; private set; }
         public string Username { get; private set; }
-        public string Password { get; private set; }
-        public bool UseWindowsAuthCustomUsernamePassword => !string.IsNullOrEmpty(Username) || !string.IsNullOrEmpty(Password);
+        public SecureString Password { get; private set; }
+        public bool UseWindowsAuthCustomUsernamePassword => !string.IsNullOrEmpty(Username) || Password.Length > 0;
     }
 }

--- a/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
+++ b/src/ServiceInsight/ServiceControl/ServiceControlConnectionProvider.cs
@@ -1,19 +1,22 @@
 ﻿namespace ServiceInsight.ServiceControl
 {
-    using Caliburn.Micro;
-
     public class ServiceControlConnectionProvider
     {
         public ServiceControlConnectionProvider()
         {
         }
 
-        public void ConnectTo(string url)
+        public void ConnectTo(string url, string username = null, string password = null)
         {
             Url = url;
+            Username = username;
+            Password = password;
             //eventAggregator.PublishOnUIThread(new ServiceControlConnectionChanged());
         }
 
         public string Url { get; private set; }
+        public string Username { get; private set; }
+        public string Password { get; private set; }
+        public bool UseWindowsAuthCustomUsernamePassword => !string.IsNullOrEmpty(Username) || !string.IsNullOrEmpty(Password);
     }
 }

--- a/src/ServiceInsight/Settings/ProfilerSettings.cs
+++ b/src/ServiceInsight/Settings/ProfilerSettings.cs
@@ -63,6 +63,15 @@
 
         public string DefaultLastUsedServiceControl { get; set; }
 
+        [DefaultValue(false)]
+        [DisplayName("Use Windows Authentication with a Custom Username Password")]
+        [Description("Use Windows integrated authentication for ServiceControl with a Custom Username Password")]
+        public bool UseWindowsAuthWithCustomUsernamePassword { get; set; } = false;
+
+        [DisplayName("Windows Authentication Custom Username")]
+        [Description("Username for authentication Windows Authentication")]
+        public string WindowsAuthenticationCustomUsername { get; set; }
+
         [DisplayName("Usage Data Collection Approved")]
         [DefaultValue(false)]
         public bool DataCollectionApproved { get; set; }

--- a/src/ServiceInsight/Shell/ServiceControlConnectionView.xaml
+++ b/src/ServiceInsight/Shell/ServiceControlConnectionView.xaml
@@ -8,7 +8,7 @@
               xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
               xmlns:shell="clr-namespace:ServiceInsight.Shell"
               Width="380"
-              Height="180"
+              Height="260"
               AutomationProperties.AutomationId="ServiceControlConnectionDialog"
               FocusManager.FocusedElement="{Binding ElementName=name}"
               Icon="{StaticResource Shell_ToolbarConnect}"
@@ -22,7 +22,13 @@
               d:DesignWidth="300"
               mc:Ignorable="d">
     <Grid>
+        <Grid.Resources>
+            <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        </Grid.Resources>
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -58,7 +64,66 @@
                                          Mode=TwoWay,
                                          UpdateSourceTrigger=PropertyChanged}" />
 
-        <Grid Grid.Row="1"
+        <CheckBox Grid.Row="1"
+                  Grid.Column="0"
+                  Grid.ColumnSpan="2"
+                  Margin="10,5,5,5"
+                  Content="Use Windows Authentication with username and password"
+                  IsChecked="{Binding UseWindowsAuthWithCustomUsernamePassword, Mode=TwoWay}" />
+
+        <StackPanel Grid.Row="2"
+                    Grid.Column="0"
+                    Margin="3"
+                    Orientation="Horizontal"
+                    Visibility="{Binding UseWindowsAuthWithCustomUsernamePassword, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Image Width="16"
+                   Height="16"
+                   Margin="5"
+                   VerticalAlignment="Center"
+                   Source="{StaticResource Shell_Information}">
+                <Image.ToolTip>
+                    <TextBlock Text="Please enter username." />
+                </Image.ToolTip>
+            </Image>
+            <TextBlock Margin="5"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       Text="Username:" />
+        </StackPanel>
+        <dxe:TextEdit Grid.Row="2"
+                      Grid.Column="1"
+                      Margin="5"
+                      AutomationProperties.AutomationId="Username"
+                      Text="{Binding Username, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                      Visibility="{Binding UseWindowsAuthWithCustomUsernamePassword, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+        <StackPanel Grid.Row="3"
+                    Grid.Column="0"
+                    Margin="3"
+                    Orientation="Horizontal"
+                    Visibility="{Binding UseWindowsAuthWithCustomUsernamePassword, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <Image Width="16"
+                   Height="16"
+                   Margin="5"
+                   VerticalAlignment="Center"
+                   Source="{StaticResource Shell_Information}">
+                <Image.ToolTip>
+                    <TextBlock Text="Please enter password." />
+                </Image.ToolTip>
+            </Image>
+            <TextBlock Margin="5"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       Text="Password:" />
+        </StackPanel>
+        <PasswordBox Grid.Row="3"
+                     Grid.Column="1"
+                     Margin="5"
+                     AutomationProperties.AutomationId="Password"
+                     cal:Message.Attach="[Event PasswordChanged] = [Action PasswordChanged($source)]"
+                     Visibility="{Binding UseWindowsAuthWithCustomUsernamePassword, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
+        <Grid Grid.Row="4"
               Grid.Column="0"
               Grid.ColumnSpan="2"
               Margin="3"
@@ -87,7 +152,7 @@
                        TextWrapping="Wrap" />
         </Grid>
 
-        <StackPanel Grid.Row="2"
+        <StackPanel Grid.Row="5"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
                     Margin="5"

--- a/src/ServiceInsight/Shell/ServiceControlConnectionViewModel.cs
+++ b/src/ServiceInsight/Shell/ServiceControlConnectionViewModel.cs
@@ -10,6 +10,7 @@
     using Framework.Settings;
     using Settings;
     using System.Windows.Controls;
+    using System.Security;
 
     public class ServiceControlConnectionViewModel : Screen
     {
@@ -55,11 +56,11 @@
 
         public string Username { get; set; }
 
-        public string Password { get; set; }
+        public SecureString Password { get; set; }
 
         public void PasswordChanged(PasswordBox passwordBox)
         {
-            Password = passwordBox.Password;
+            Password = passwordBox.SecurePassword;
         }
 
         protected override void OnActivate()


### PR DESCRIPTION
Allows users who follow the directions to [Install ServicePulse in IIS](https://docs.particular.net/servicepulse/install-servicepulse-in-iis) to allow users to provide a username and password other than the one they're currently logged in as locally.

 ![Screenshot 2025-03-13 193018](https://github.com/user-attachments/assets/2f29bc4b-c9b8-4834-9de2-98351dab3476)
