### PR TITLE
Display Deprecation Date in ServiceInsight UI

### DIFF
--- a/src/ServiceInsight/Shell/About.xaml
+++ b/src/ServiceInsight/Shell/About.xaml
@@ -68,8 +68,19 @@
                     <Run Text="www.particular.net" />
                 </Hyperlink>
             </TextBlock>
-
-            <TextBlock Text="{Binding CopyrightText}" Canvas.Left="38" Canvas.Top="262" />
+            <TextBlock Canvas.Left="38"
+                       Canvas.Top="262"
+                       FontFamily="Tahoma"
+                       FontSize="10"
+                       FontWeight="Bold"
+                      >
+                   <Run Text="Serviceinsight will be" />
+                <Hyperlink Command="{Binding NavigateToServiceInsightSupportPolicyCommand}">
+                    <Run Text="deprecated" />
+                </Hyperlink>
+                 <Run Text="as of February 10 2027." />
+            </TextBlock>
+            <TextBlock Text="{Binding CopyrightText}" Canvas.Left="38" Canvas.Top="282" />
         </Canvas>
     </Grid>
 </Window>

--- a/src/ServiceInsight/Shell/AboutViewModel.cs
+++ b/src/ServiceInsight/Shell/AboutViewModel.cs
@@ -1,14 +1,14 @@
 namespace ServiceInsight.Shell
 {
-    using System.Linq;
-    using ServiceInsight.ServiceControl;
     using System;
     using System.ComponentModel;
+    using System.Linq;
     using System.Threading.Tasks;
     using System.Windows.Input;
     using Caliburn.Micro;
     using ServiceInsight.Framework;
     using ServiceInsight.Framework.Licensing;
+    using ServiceInsight.ServiceControl;
 
     public class AboutViewModel : INotifyPropertyChanged, IActivate, IHaveDisplayName
     {
@@ -35,7 +35,7 @@ namespace ServiceInsight.Shell
         public string ServiceControlVersion { get; private set; }
 
         public string CopyrightText { get; private set; }
-
+        public ICommand NavigateToServiceInsightSupportPolicyCommand { get; }
         public string DisplayName { get; set; }
 
         public string CommitHash { get; private set; }
@@ -43,7 +43,7 @@ namespace ServiceInsight.Shell
         public bool IsActive { get; private set; }
 
         public ICommand NavigateToSiteCommand { get; }
-
+        public string SupportPolicyUrl => "https://docs.particular.net/serviceinsight/support-policy";
         public AboutViewModel(
             NetworkOperations networkOperations,
             IApplicationVersionService applicationVersionService,
@@ -57,6 +57,8 @@ namespace ServiceInsight.Shell
             DisplayName = "About";
 
             NavigateToSiteCommand = Command.Create(() => networkOperations.Browse("http://www.particular.net"));
+            NavigateToServiceInsightSupportPolicyCommand = Command.Create(() => networkOperations.Browse(SupportPolicyUrl));
+
         }
 
         AboutViewModel(IApplicationVersionService applicationVersionService)

--- a/src/ServiceInsight/Shell/Shell.xaml
+++ b/src/ServiceInsight/Shell/Shell.xaml
@@ -167,6 +167,30 @@
                                Command="{Binding ResetLayoutCommand}"
                                CustomizationContent="Reset Layout"
                                Content="Restore default layout" />
+            <dxb:BarStaticItem x:Name="SunsetBanner"
+    AutoSizeMode="Content"
+    CustomizationContent="Sunset Banner"
+    CategoryName="Status"
+    ShowBorder="False"
+    Content="{Binding}">
+                <dxb:BarStaticItem.ContentTemplate>
+                    <DataTemplate>
+                        <Border Background="#FFF9C400" BorderBrush="#FFDFA600" BorderThickness="1" Padding="4,0,4,0" Height="28">
+                            <Grid HorizontalAlignment="Center">
+                                <TextBlock FontWeight="Bold" FontSize="12" VerticalAlignment="Center">
+                        <Run Text="Serviceinsight will be" />
+                        <Hyperlink NavigateUri="https://docs.particular.net/serviceinsight/support-policy"
+                                   ToolTip="View support policy"
+                                   RequestNavigate="Hyperlink_RequestNavigate">
+                            <Run Text="deprecated" />
+                        </Hyperlink>
+                        <Run Text="as of February 10 2027" />
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </dxb:BarStaticItem.ContentTemplate>
+            </dxb:BarStaticItem>
             <dxb:BarButtonItem x:Name="ProvideFeedback"
                                AutomationProperties.AutomationId="ProvideFeedbackMenuItem"
                                CategoryName="Help"
@@ -195,6 +219,7 @@
                     </DataTemplate>
                 </dxb:BarButtonItem.ContentTemplate>
             </dxb:BarButtonItem>
+           
             <dxb:BarCheckItem Name="DataAutoRefresh"
                               AutomationProperties.AutomationId="DataAutoRefreshMenuItem"
                               CustomizationContent="Auto Data Refresh"
@@ -409,7 +434,9 @@
                 <dxb:BarItemLinkSeparator />
                 <dxb:BarCheckItemLink BarItemName="DataAutoRefresh" />
                 <dxb:BarCheckItemLink BarItemName="RetryMessage" />
+                <dxb:BarStaticItemLink BarItemName="SunsetBanner" Alignment="Far" />
                 <dxb:BarButtonItemLink BarItemName="ProvideFeedbackToolbar" Alignment="Far" />
+                
             </dxb:Bar>
             <dxb:Bar x:Name="StatusBar"
                      AllowCollapse="True"

--- a/src/ServiceInsight/Shell/Shell.xaml.cs
+++ b/src/ServiceInsight/Shell/Shell.xaml.cs
@@ -1,6 +1,8 @@
 ﻿namespace ServiceInsight.Shell
 {
+    using System.Diagnostics;
     using System.Windows;
+    using System.Windows.Navigation;
     using DevExpress.Xpf.Bars;
     using DevExpress.Xpf.Core;
     using DevExpress.Xpf.Core.Serialization;
@@ -18,6 +20,11 @@
             InitializeComponent();
             BarManager.CheckBarItemNames = false;
             Loaded += OnShellLoaded;
+        }
+        void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            Process.Start(new ProcessStartInfo(e.Uri.AbsoluteUri) { UseShellExecute = true });
+            e.Handled = true;
         }
 
         void OnShellLoaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- https://github.com/Particular/ServiceInsight/issues/1647

Following the sunset notice in our [support policy](https://docs.particular.net/serviceinsight/support-policy), this PR adds the deprecation date in the tool bar and the about page for visibility 