### PR TITLE
Remove the filter by actor from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ defaults:
     shell: pwsh
 jobs:
   release:
-    if: ${{ github.actor != 'dependencyupdates[bot]' }}
     runs-on: windows-latest
     steps:
       - name: Check for secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ defaults:
     shell: pwsh
 jobs:
   release:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependencyupdates[bot]' }}
     runs-on: windows-latest
     steps:
       - name: Check for secrets


### PR DESCRIPTION
This PR removes the filter by actor, given that was added because Dependabot wasn't allow to sign the artifacts. Now Renovate can handle that, so we don't need the filter anymore.