### PR TITLE
Setup project tweaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build Windows installer
         env:
           AZURE_KEY_VAULT_CLIENT_SECRET: ${{ secrets.AZURE_KEY_VAULT_CLIENT_SECRET }}
-        run: msbuild src/Setup -p:Configuration=Release -restore -m
+        run: dotnet build src/Setup --configuration Release
       - name: Publish artifacts
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/src/ServiceInsight.slnx
+++ b/src/ServiceInsight.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/Installer/">
+    <File Path="Setup/Setup.csproj" />
+  </Folder>
   <Folder Name="/Solution Items/">
     <File Path="Custom.Build.props" />
     <File Path="Setup/Setup.csproj" />

--- a/src/Setup/Setup.csproj
+++ b/src/Setup/Setup.csproj
@@ -12,10 +12,6 @@
     <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ServiceInsight\ServiceInsight.csproj" />
-  </ItemGroup>
-
   <Target Name="CreateInstaller" AfterTargets="Build">
     <PropertyGroup>
       <AdvancedInstallerPath>$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Caphyon\Advanced Installer@Advanced Installer Path)</AdvancedInstallerPath>


### PR DESCRIPTION
This PR makes a few additional changes to the Setup project:

- The Setup project file has been moved into the Installer folder.
- The ServiceInsight project reference in the Setup project should not have been there given that we require the solution to be built first anyway.
- With that reference gone, we can once again use `dotnet build` in the release workflow to build the Setup project.

Follow-up to #1691 and #1680
